### PR TITLE
Pass public_key in param instead of url path

### DIFF
--- a/app/assets/javascripts/uploadcare/widget/tabs/remote-tab.js.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/remote-tab.js.coffee
@@ -27,7 +27,7 @@ uploadcare.whenReady ->
 
             src =
               "#{@settings.socialBase}/window/#{@windowId}/" +
-              "#{service}/#{@settings.publicKey}?lang=#{locale.lang}"
+              "#{service}?lang=#{locale.lang}&public_key=#{@settings.publicKey}"
             @iframe = $('<iframe>')
               .attr('src', src)
               .css


### PR DESCRIPTION
Как я понимаю, версии виджета, где public_key был бы частью url нет в паблике. Поэтому мы можем передавать его в параметрах, что будет лучше для social.
