### PR TITLE
get rid of file.current()

### DIFF
--- a/app/assets/javascripts/uploadcare/files/event.js.coffee
+++ b/app/assets/javascripts/uploadcare/files/event.js.coffee
@@ -15,6 +15,7 @@ namespace 'uploadcare.files', (ns) ->
       @fileSize = @__file.size
       @fileName = @__file.name
       @previewUrl = utils.createObjectUrl @__file
+      @__notifyApi()
 
     __startUpload: ->
       targetUrl = "#{@settings.urlBase}/iframe/"

--- a/app/assets/javascripts/uploadcare/files/input.js.coffee
+++ b/app/assets/javascripts/uploadcare/files/input.js.coffee
@@ -10,6 +10,7 @@ namespace 'uploadcare.files', (ns) ->
       super
       @fileId = utils.uuid()
       @fileName = $(@__input).val().split('\\').pop()
+      @__notifyApi()
 
     __startUpload: ->
       targetUrl = "#{@settings.urlBase}/iframe/"

--- a/app/assets/javascripts/uploadcare/files/url.js.coffee
+++ b/app/assets/javascripts/uploadcare/files/url.js.coffee
@@ -21,6 +21,7 @@ namespace 'uploadcare.files', (ns) ->
       @__tmpFinalPreviewUrl = @__url
 
       @fileName = utils.parseUrl(@__url).pathname.split('/').pop() or null
+      @__notifyApi()
 
     __startUpload: ->
 

--- a/app/assets/javascripts/uploadcare/utils.js.coffee
+++ b/app/assets/javascripts/uploadcare/utils.js.coffee
@@ -10,6 +10,15 @@ namespace 'uploadcare.utils', (ns) ->
   ns.defer = (fn) ->
     setTimeout fn, 0
 
+  ns.once = (fn) ->
+    called = false
+    result = null
+    ->
+      unless called
+        result = fn.apply(this, arguments)
+        called = true
+      result
+
   ns.bindAll = (source, methods) ->
     target = {}
     for method in methods

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.js.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.js.coffee
@@ -42,9 +42,10 @@ namespace 'uploadcare.widget.tabs', (ns) ->
     # image
     # regular
     __setState: (state, data) ->
-      data = $.extend {file: @file.current()}, data
-      @content.empty().append tpl("tab-preview-#{state}", data)
-      @__afterRender state
+      @file.progress utils.once (progressInfo) =>
+        data = $.extend {file: progressInfo.incompleteFileInfo}, data
+        @content.empty().append tpl("tab-preview-#{state}", data)
+        @__afterRender state
 
     __afterRender: (state) ->
       if state is 'unknown'


### PR DESCRIPTION
Убрал `file.current()`, добавил `progressInfo.incompleteFileInfo`.

Потому что:

1) Не можем поддерживать актуальным `file.current()`.
2) `progressInfo.incompleteFileInfo` удобно пользоваться. У меня есть файл на странице, я подписываюсь на `progress`, и как что меняется, меняю это в отображаемом файле.
