### PR TITLE
Build branch

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -183,7 +183,6 @@ namespace :js do
     end
   end
 
-
   task latest: ["latest:build", "latest:upload"]
   task release: ["release:build", "release:upload"]
 end


### PR DESCRIPTION
Билдятся новые бранчи (в которых этот код есть):

https://uploadcare-static.s3.amazonaws.com/widget/latest-build_branch/uploadcare/uploadcare-latest-build_branch.min.js

Надо в вебклиенте исправить, чтобы ссылки http://staging0.uploadcare.com/widget/build_branch/ пахали. Еще можно убрать `latest` и использовать `latest-master`.
