### PR TITLE
public drag-and-drop api

### DIFF
--- a/app/assets/javascripts/uploadcare/core/namespace.coffee
+++ b/app/assets/javascripts/uploadcare/core/namespace.coffee
@@ -18,4 +18,15 @@ uploadcare.namespace = (path, fn) ->
   fn(target)
 
 uploadcare.expose = (key, value) ->
-  window.uploadcare[key] = value || uploadcare[key]
+  parts = key.split('.')
+  last = parts.pop()
+
+  target = window.uploadcare
+  source = uploadcare
+
+  for part in parts
+    target[part] ||= {}
+    target = target[part]
+    source = source?[part]
+
+  target[last] = value || source[last]

--- a/app/assets/javascripts/uploadcare/widget.js.coffee.erb
+++ b/app/assets/javascripts/uploadcare/widget.js.coffee.erb
@@ -26,3 +26,6 @@ expose 'Circle', uploadcare.ui.progress.Circle
 expose 'Widget'
 expose 'MultipleWidget'
 expose 'plugin', uploadcare.utils.plugin
+expose 'dragdrop.support'
+expose 'dragdrop.receiveDrop'
+expose 'dragdrop.uploadDrop'

--- a/app/assets/javascripts/uploadcare/widget/base-widget.js.coffee
+++ b/app/assets/javascripts/uploadcare/widget/base-widget.js.coffee
@@ -11,6 +11,7 @@
   utils,
   settings: s,
   jQuery: $,
+  dragdrop,
   locale: {t}
 } = uploadcare
 
@@ -48,7 +49,7 @@ namespace 'uploadcare.widget', (ns) ->
         dialogButton.on 'click', => @openDialog()
 
       # Enable drag and drop
-      ns.dragdrop.receiveDrop(@__handleDirectSelection, @template.dropArea)
+      dragdrop.receiveDrop(@template.dropArea, @__handleDirectSelection)
       @template.dropArea.on 'dragstatechange.uploadcare', (e, active) =>
         unless active && uploadcare.isDialogOpened()
           @template.dropArea.toggleClass('uploadcare-dragging', active)

--- a/app/assets/javascripts/uploadcare/widget/dragdrop.js.coffee
+++ b/app/assets/javascripts/uploadcare/widget/dragdrop.js.coffee
@@ -1,14 +1,23 @@
 {
   namespace,
   utils,
+  settings: s,
   jQuery: $
 } = uploadcare
 
-namespace 'uploadcare.widget.dragdrop', (ns) ->
-  unless utils.abilities.fileDragAndDrop
+namespace 'uploadcare.dragdrop', (ns) ->
+  ns.support = utils.abilities.fileDragAndDrop
+
+  ns.uploadDrop = (el, callback, settings) ->
+    settings = s.build settings
+    ns.receiveDrop el, (type, data) ->
+      method = if settings.multiple then 'filesFrom' else 'fileFrom'
+      callback uploadcare[method](type, data, settings)
+
+  unless ns.support
     ns.receiveDrop = ->
   else
-    ns.receiveDrop = (upload, el) ->
+    ns.receiveDrop = (el, callback) ->
       $(el)
         .on 'dragover', (e) ->
           e.stopPropagation() # Prevent redirect
@@ -21,13 +30,13 @@ namespace 'uploadcare.widget.dragdrop', (ns) ->
           delayedDragState off, 0
           dt = e.originalEvent.dataTransfer
           if dt.files.length
-            upload('event', e)
+            callback('event', e)
           else
             uris = dt.getData('text/uri-list')
             if uris
               # opera likes to add \n at the end
               uris = uris.replace /\n$/, ''
-              upload('url', uris)
+              callback('url', uris)
           false
 
     onDelay = 0

--- a/app/assets/javascripts/uploadcare/widget/tabs/file-tab.js.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/file-tab.js.coffee
@@ -1,11 +1,10 @@
 {
   namespace,
   utils,
+  dragdrop,
   jQuery: $,
   templates: {tpl}
 } = uploadcare
-
-{dragdrop} = uploadcare.widget
 
 namespace 'uploadcare.widget.tabs', (ns) ->
   class ns.FileTab extends ns.BaseSourceTab
@@ -24,10 +23,9 @@ namespace 'uploadcare.widget.tabs', (ns) ->
     __initDragNDrop: ->
       dropArea = @wrap.find('@uploadcare-drop-area')
       if utils.abilities.fileDragAndDrop
-        dragdrop.receiveDrop (type, data) =>
+        dragdrop.receiveDrop dropArea, (type, data) =>
           @dialogApi.addFiles type, data
           @dialogApi.switchToPreview()
-        , dropArea
         className = 'draganddrop'
       else
         className = 'no-draganddrop'

--- a/app/assets/javascripts/uploadcare/widget/widget.js.coffee
+++ b/app/assets/javascripts/uploadcare/widget/widget.js.coffee
@@ -2,6 +2,7 @@
   namespace,
   utils,
   settings: s,
+  files,
   jQuery: $
 } = uploadcare
 


### PR DESCRIPTION
https://trello.com/card/drag-n-drop/51a892188904f26a04006d8b/11

`uploadcare.dragdrop.support` — поддерживает ли браузер drag and drop (true / false)
`uploadcare.dragdrop.uploadDrop(el, callback[, settings])` — получить объекты файлов после дропа на элемент `el`
`uploadcare.dragdrop.receiveDrop(el, callback)` — получить сырые данные после дропа

`el` — DOM-элемент, селектор или jQuery-объект
# Примеры

Загрузить один файл (если перетащили несколько, первый):

``` javascript
uploadcare.dragdrop.uploadDrop(el, function(file) {
  file.done(...);
});
```

Загрузить все файлы:

``` javascript
uploadcare.dragdrop.uploadDrop(el, function(files) {
  files; // массив
}, {multiple: true});
```

Сырые данные после дропа:

``` javascript
uploadcare.dragdrop.receiveDrop(el, function(type, data) {
  type; // 'event' or 'url'
  data; // Event (object) or URL (string)

  // Получение файла (первого если несколько)
  var file = uploadcare.fileFrom(type, data);

  // Получение всех файлов
  var fileArray = uploadcare.filesFrom(type, data);
});
```
