### PR TITLE
Robust input value

### DIFF
--- a/app/assets/javascripts/uploadcare/files/group.js.coffee
+++ b/app/assets/javascripts/uploadcare/files/group.js.coffee
@@ -11,6 +11,7 @@ namespace 'uploadcare.files', (ns) ->
   class ns.FileGroup
 
     constructor: (files, settings) ->
+      @__uuid = null
       @settings = s.build settings
       @__fileColl = new utils.CollectionOfPromises(files)
 
@@ -87,7 +88,7 @@ namespace 'uploadcare.files', (ns) ->
     __buildInfo: (cb) ->
       info = 
         uuid: @__uuid
-        cdnUrl: "#{@settings.cdnBase}/#{@__uuid}/"
+        cdnUrl: if @__uuid then "#{@settings.cdnBase}/#{@__uuid}/" else null
         name: t('file', @__fileColl.length())
         count: @__fileColl.length()
         size: 0

--- a/app/assets/javascripts/uploadcare/widget.js.coffee.erb
+++ b/app/assets/javascripts/uploadcare/widget.js.coffee.erb
@@ -31,6 +31,7 @@ expose 'registerTab'
 expose 'Circle', uploadcare.ui.progress.Circle
 expose 'Widget'
 expose 'MultipleWidget'
+expose 'AnyWidget'
 expose 'plugin', uploadcare.utils.plugin
 expose 'tabsCss'
 expose 'dragdrop.support'

--- a/app/assets/javascripts/uploadcare/widget/base-widget.js.coffee
+++ b/app/assets/javascripts/uploadcare/widget/base-widget.js.coffee
@@ -56,6 +56,7 @@ namespace 'uploadcare.widget', (ns) ->
       if @settings.clearable
         @template.addButton('remove', t('buttons.remove')).on 'click', =>
           @__setObject(null)
+          @element.val('')
 
       @template.content.on 'click', '@uploadcare-widget-file-name', =>
         @openDialog()
@@ -77,7 +78,6 @@ namespace 'uploadcare.widget', (ns) ->
       @currentObject = null
       object?.cancel?()
       @template.reset()
-      @element.val('')
 
     __setObject: (newFile) =>
       unless newFile == @currentObject

--- a/app/assets/javascripts/uploadcare/widget/base-widget.js.coffee
+++ b/app/assets/javascripts/uploadcare/widget/base-widget.js.coffee
@@ -56,7 +56,6 @@ namespace 'uploadcare.widget', (ns) ->
       if @settings.clearable
         @template.addButton('remove', t('buttons.remove')).on 'click', =>
           @__setObject(null)
-          @element.val('')
 
       @template.content.on 'click', '@uploadcare-widget-file-name', =>
         @openDialog()
@@ -80,12 +79,14 @@ namespace 'uploadcare.widget', (ns) ->
       @template.reset()
 
     __setObject: (newFile) =>
-      unless newFile == @currentObject
+      if newFile != @currentObject
         @__reset()
         if newFile
           @currentObject = newFile
           @__watchCurrentObject()
-        @__onChange.fire @currentObject
+        @__onChange.fire(@currentObject)
+      if not newFile
+        @element.val('')
 
     __watchCurrentObject: ->
       object = @__currentFile()
@@ -105,8 +106,8 @@ namespace 'uploadcare.widget', (ns) ->
       @template.loaded()
 
     __onUploadingFailed: (error) ->
-      @__setObject(null)
-      @template.error error
+      @template.reset()
+      @template.error(error)
 
     __setExternalValue: (value) ->
       @__setObject utils.valueToFile(value, @settings)
@@ -120,7 +121,7 @@ namespace 'uploadcare.widget', (ns) ->
         @currentObject
 
     reloadInfo: =>
-      @value @element.val()
+      @value(@element.val())
 
     openDialog: (tab) ->
       if @settings.systemDialog

--- a/app/assets/javascripts/uploadcare/widget/live.js.coffee
+++ b/app/assets/javascripts/uploadcare/widget/live.js.coffee
@@ -21,11 +21,7 @@ namespace 'uploadcare', (ns) ->
         # widget already exists
         continue
 
-      widgetClass = if getSettings(target).multiple
-        ns.widget.MultipleWidget
-      else
-        ns.widget.Widget
-      initializeWidget($(target), widgetClass)
+      ns.AnyWidget(target)
 
   ns.Widget = (target) ->
     el = $(target).eq(0)
@@ -40,6 +36,14 @@ namespace 'uploadcare', (ns) ->
       initializeWidget(el, ns.widget.MultipleWidget)
     else
       throw new Error 'This element should be processed using Widget'
+
+  ns.AnyWidget = (target) ->
+    el = $(target).eq(0)
+    widgetClass = if getSettings(el).multiple
+      ns.widget.MultipleWidget
+    else
+      ns.widget.Widget
+    initializeWidget(el, widgetClass)
 
   initializeWidget = (el, Widget) ->
     widget = el.data(dataAttr)

--- a/app/assets/javascripts/uploadcare/widget/multiple-widget.js.coffee
+++ b/app/assets/javascripts/uploadcare/widget/multiple-widget.js.coffee
@@ -12,13 +12,14 @@ namespace 'uploadcare.widget', (ns) ->
       @currentObject?.promise()
 
     __setObject: (group) =>
-      unless utils.isFileGroupsEqual(@currentObject, group)
+      if not utils.isFileGroupsEqual(@currentObject, group)
         super
 
     __setExternalValue: (value) ->
       @__lastGroupPr = groupPr = utils.valueToGroup(value, @settings)
-      @template.setStatus('started')
-      @template.statusText.text(t('loadingInfo'))
+      if value
+        @template.setStatus('started')
+        @template.statusText.text(t('loadingInfo'))
       groupPr
         .done (group) =>
           if @__lastGroupPr == groupPr

--- a/app/assets/javascripts/uploadcare/widget/multiple-widget.js.coffee
+++ b/app/assets/javascripts/uploadcare/widget/multiple-widget.js.coffee
@@ -17,7 +17,6 @@ namespace 'uploadcare.widget', (ns) ->
 
     __setExternalValue: (value) ->
       @__lastGroupPr = groupPr = utils.valueToGroup(value, @settings)
-      @__reset()
       @template.setStatus('started')
       @template.statusText.text(t('loadingInfo'))
       groupPr
@@ -26,12 +25,7 @@ namespace 'uploadcare.widget', (ns) ->
             @__setObject(group)
         .fail =>
           if @__lastGroupPr == groupPr
-            @template.error('createGroup')
-
-    __onUploadingFailed: (error) ->
-      if error is 'createGroup'
-        @__setObject(null)
-      @template.error error
+            @__onUploadingFailed('createGroup')
 
     __handleDirectSelection: (type, data) =>
       files = uploadcare.filesFrom(type, data, @settings)

--- a/app/assets/javascripts/uploadcare/widget/multiple-widget.js.coffee
+++ b/app/assets/javascripts/uploadcare/widget/multiple-widget.js.coffee
@@ -12,21 +12,21 @@ namespace 'uploadcare.widget', (ns) ->
       @currentObject?.promise()
 
     __setObject: (group) =>
-      unless utils.isFileGroupsEqual @currentObject, group
+      unless utils.isFileGroupsEqual(@currentObject, group)
         super
 
     __setExternalValue: (value) ->
       @__lastGroupPr = groupPr = utils.valueToGroup(value, @settings)
       @__reset()
-      @template.setStatus 'started'
-      @template.statusText.text t('loadingInfo')
+      @template.setStatus('started')
+      @template.statusText.text(t('loadingInfo'))
       groupPr
         .done (group) =>
           if @__lastGroupPr == groupPr
-            @__setObject group
+            @__setObject(group)
         .fail =>
           if @__lastGroupPr == groupPr
-            @template.error 'createGroup'
+            @template.error('createGroup')
 
     __onUploadingFailed: (error) ->
       if error is 'createGroup'
@@ -36,6 +36,6 @@ namespace 'uploadcare.widget', (ns) ->
     __handleDirectSelection: (type, data) =>
       files = uploadcare.filesFrom(type, data, @settings)
       if @settings.systemDialog
-        @__setObject uploadcare.FileGroup(files, @settings)
+        @__setObject(uploadcare.FileGroup(files, @settings))
       else
         uploadcare.openDialog(files, @settings).done(@__setObject)

--- a/app/assets/javascripts/uploadcare/widget/widget.js.coffee
+++ b/app/assets/javascripts/uploadcare/widget/widget.js.coffee
@@ -14,6 +14,6 @@ namespace 'uploadcare.widget', (ns) ->
     __handleDirectSelection: (type, data) =>
       file = uploadcare.fileFrom(type, data[0], @settings)
       if @settings.systemDialog or not @settings.previewStep
-        @__setObject file
+        @__setObject(file)
       else
         uploadcare.openDialog(file, @settings).done(@__setObject)

--- a/test/dummy/app/views/welcome/with_value.html.erb
+++ b/test/dummy/app/views/welcome/with_value.html.erb
@@ -1,17 +1,45 @@
+<style>
+  input {
+    width: 300px;
+    display: block;
+  }
+</style>
+
+
 <p>With CDN URL value:<br>
-  <input type="hidden" data-public-key="4e403b891fa45b0b5f5b" role="uploadcare-uploader" value="http://staging0.ucarecdn.com/f1577f70-7559-4f87-97a7-86801d8f1753/-/crop/200x300/center/-/scale_crop/100x100/center/" data-crop/></p>
+  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader"
+         value="https://ucarecdn.com/a15a0473-5262-48c7-82e3-2fefcd14e293/-/crop/200x300/center/-/scale_crop/100x100/center/" data-crop/>
+  <button>Clear</button>
 
 <p>With custom domain CDN URL value:<br>
-  <input type="hidden" data-public-key="4e403b891fa45b0b5f5b" role="uploadcare-uploader" value="http://my-static.com/f1577f70-7559-4f87-97a7-86801d8f1753/-/scale_crop/100x100/center/" /></p>
+  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader"
+         value="http://my-static.com/a15a0473-5262-48c7-82e3-2fefcd14e293/-/scale_crop/100x100/center/" />
+  <button>Clear</button>
 
 <p>With UUID value:<br>
-  <input type="hidden" data-public-key="4e403b891fa45b0b5f5b" role="uploadcare-uploader" value="f1577f70-7559-4f87-97a7-86801d8f1753" /></p>
+  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader"
+         value="a15a0473-5262-48c7-82e3-2fefcd14e293" />
+  <button>Clear</button>
 
 <p>With custom URL value (incorrect): <br>
-  <input type="hidden" data-public-key="4e403b891fa45b0b5f5b" role="uploadcare-uploader" value="https://staging0.ucarecdn.com/assets/images/olympia.0939bbb3e820.jpg" /></p>
+  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader"
+         value="https://staging0.ucarecdn.com/assets/images/olympia.0939bbb3e820.jpg" />
+  <button>Clear</button>
 
 <p>With invalid value:<br>
-  <input type="hidden" data-public-key="4e403b891fa45b0b5f5b" role="uploadcare-uploader" value="error" /></p>
+  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader"
+         value="error" />
+  <button>Clear</button>
 
 <p>With invalid UUID value:<br>
-  <input type="hidden" data-public-key="4e403b891fa45b0b5f5b" role="uploadcare-uploader" value="error/f1577f70-7559-4f87-97a7-86801d8f1753" /></p>
+  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader"
+         value="error/a15a0473-5262-48c7-82e3-2fefcd14e293" />
+  <button>Clear</button>
+
+
+<script>
+  UPLOADCARE_CLEARABLE = true;
+  $('p > button').on('click', function() {
+    uploadcare.Widget($(this).prevAll('input')).value(null);
+  });
+</script>

--- a/test/dummy/app/views/welcome/with_value.html.erb
+++ b/test/dummy/app/views/welcome/with_value.html.erb
@@ -42,18 +42,29 @@
   <button>Clear</button>
 
 
+<p>Group UUID:<br>
+  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader" name="GroupUUID"
+         value="cd334b26-c641-4393-bcce-b5041546430d~11" data-images-only="" data-multiple="true"/>
+  <button>Clear</button>
+
+<p>Group incorrect:<br>
+  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader" name="GroupIncorrect"
+         value="cd334b26-c641-4393-bcce-b5041546430d~" data-images-only="" data-multiple="true"/>
+  <button>Clear</button>
+
+
 <script>
   UPLOADCARE_CLEARABLE = true;
   $('p > button').on('click', function() {
-    uploadcare.Widget($(this).prevAll('input')).value(null);
+    uploadcare.AnyWidget($(this).prevAll('input')).value(null);
   });
 
   $('input[role="uploadcare-uploader"]').each(function() {
     var input = this;
-    uploadcare.Widget(input).onChange(function(file) {
+    uploadcare.AnyWidget(input).onChange(function(file) {
       console.log('change:', input.name, file);
       if (file) {
-        file
+        file.promise()
           .done(function(info) {
             console.log('done:', input.name, info);
           })

--- a/test/dummy/app/views/welcome/with_value.html.erb
+++ b/test/dummy/app/views/welcome/with_value.html.erb
@@ -7,33 +7,38 @@
 
 
 <p>With CDN URL value:<br>
-  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader"
+  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader" name="CDNURL"
          value="https://ucarecdn.com/a15a0473-5262-48c7-82e3-2fefcd14e293/-/crop/200x300/center/-/scale_crop/100x100/center/" data-crop/>
   <button>Clear</button>
 
 <p>With custom domain CDN URL value:<br>
-  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader"
+  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader" name="CustomDomain"
          value="http://my-static.com/a15a0473-5262-48c7-82e3-2fefcd14e293/-/scale_crop/100x100/center/" />
   <button>Clear</button>
 
 <p>With UUID value:<br>
-  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader"
+  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader" name="UUID"
          value="a15a0473-5262-48c7-82e3-2fefcd14e293" />
   <button>Clear</button>
 
 <p>With custom URL value (incorrect): <br>
-  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader"
+  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader" name="InvalidURL"
          value="https://staging0.ucarecdn.com/assets/images/olympia.0939bbb3e820.jpg" />
   <button>Clear</button>
 
 <p>With invalid value:<br>
-  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader"
+  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader" name="Invalid"
          value="error" />
   <button>Clear</button>
 
 <p>With invalid UUID value:<br>
-  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader"
+  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader" name="InvalidUUID"
          value="error/a15a0473-5262-48c7-82e3-2fefcd14e293" />
+  <button>Clear</button>
+
+<p>Empty:<br>
+  <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader" name="Empty"
+         value="" data-images-only=""/>
   <button>Clear</button>
 
 
@@ -41,5 +46,21 @@
   UPLOADCARE_CLEARABLE = true;
   $('p > button').on('click', function() {
     uploadcare.Widget($(this).prevAll('input')).value(null);
+  });
+
+  $('input[role="uploadcare-uploader"]').each(function() {
+    var input = this;
+    uploadcare.Widget(input).onChange(function(file) {
+      console.log('change:', input.name, file);
+      if (file) {
+        file
+          .done(function(info) {
+            console.log('done:', input.name, info);
+          })
+          .fail(function(reason, info) {
+            console.log('fail:', input.name, reason, info);
+          });
+      }
+    });
   });
 </script>


### PR DESCRIPTION
This changes address issue described by @dimier.

In the past input's value always reflects current widget value. This pr allows input's value change only in two cases:
1) new object loaded successfully
2) user removes current object by hand (widget is clearable)

In case, described by @dimier, when widget has "bad value" (malformed uuid or network error was happened) as initial input value, the user see the problem (widget says "Can’t load info" or "Incorrect value"). She can ignore it and save form without changing file (bad value will be returned to the application) or upload a new file. May be in case of "clearable" we should also show "remove" button to allow user to remove bad value.

Other cases:

* Widget is empty, user chooses a new file and network error happens. Value will be empty, like with old behavior.

* Widget already has uploaded file, user chooses a new file and network error happens. Old value will be saved in input, widget will show error. User will not be able to see or remove old file from widget. Looks like a issue