### PR TITLE
Autostore

### DIFF
--- a/app/assets/javascripts/uploadcare/files/input.js.coffee
+++ b/app/assets/javascripts/uploadcare/files/input.js.coffee
@@ -45,7 +45,7 @@ namespace 'uploadcare.files', (ns) ->
         })
         .append(formParam('UPLOADCARE_PUB_KEY', @settings.publicKey))
         .append(formParam('UPLOADCARE_FILE_ID', @fileId))
-        .append(if @settings.autostore then formParam('UPLOADCARE_STORE', 1))
+        .append(formParam('UPLOADCARE_STORE', if @settings.doNotStore then '' else 'auto'))
         .append(@__input)
         .css('display', 'none')
         .appendTo('body')

--- a/app/assets/javascripts/uploadcare/files/object.js.coffee
+++ b/app/assets/javascripts/uploadcare/files/object.js.coffee
@@ -71,8 +71,7 @@ namespace 'uploadcare.files', (ns) ->
 
       formData = new FormData()
       formData.append('UPLOADCARE_PUB_KEY', @settings.publicKey)
-      if @settings.autostore
-        formData.append('UPLOADCARE_STORE', '1')
+      formData.append('UPLOADCARE_STORE', if @settings.doNotStore then '' else 'auto')
       formData.append('file', @__file, @fileName)
       formData.append('file_name', @fileName)
 
@@ -130,8 +129,7 @@ namespace 'uploadcare.files', (ns) ->
         filename: @fileName
         size: @fileSize
         content_type: @fileType
-      if @settings.autostore
-        data.UPLOADCARE_STORE = '1'
+        UPLOADCARE_STORE: if @settings.doNotStore then '' else 'auto'
 
       @__autoAbort utils.jsonp(
         "#{@settings.urlBase}/multipart/start/?jsonerrors=1", 'POST', data

--- a/app/assets/javascripts/uploadcare/files/object.js.coffee
+++ b/app/assets/javascripts/uploadcare/files/object.js.coffee
@@ -100,8 +100,6 @@ namespace 'uploadcare.files', (ns) ->
             @fileId = data.file
             df.resolve()
           else
-            if @settings.autostore && /autostore/i.test(data.error.content)
-              utils.commonWarning('autostore')
             df.reject()
 
       df

--- a/app/assets/javascripts/uploadcare/files/url.js.coffee
+++ b/app/assets/javascripts/uploadcare/files/url.js.coffee
@@ -47,8 +47,7 @@ namespace 'uploadcare.files', (ns) ->
         pub_key: @settings.publicKey
         source_url: @__url
         filename: @__realFileName or ''
-      if @settings.autostore
-        data.store = 1
+        store: if @settings.doNotStore then '' else 'auto'
 
       utils.jsonp("#{@settings.urlBase}/from_url/", data)
         .fail(df.reject)

--- a/app/assets/javascripts/uploadcare/files/url.js.coffee
+++ b/app/assets/javascripts/uploadcare/files/url.js.coffee
@@ -51,10 +51,7 @@ namespace 'uploadcare.files', (ns) ->
         data.store = 1
 
       utils.jsonp("#{@settings.urlBase}/from_url/", data)
-        .fail (error) =>
-          if @settings.autostore && /autostore/i.test(error)
-            utils.commonWarning('autostore')
-          df.reject()
+        .fail(df.reject)
         .done (data) =>
           pusherWatcher.watch data.token
           pollWatcher.watch data.token

--- a/app/assets/javascripts/uploadcare/settings.js.coffee
+++ b/app/assets/javascripts/uploadcare/settings.js.coffee
@@ -29,7 +29,7 @@ namespace 'uploadcare.settings', (ns) ->
     'preferred-types': ''
     'input-accept-types': ''  # '' means default, null means "disable accept"
     # upload settings
-    'autostore': false
+    'do-not-store': false
     'public-key': null
     'pusher-key': '79ae88bd931ea68464d9'
     'cdn-base': 'http://www.ucarecdn.com'
@@ -124,7 +124,7 @@ namespace 'uploadcare.settings', (ns) ->
       'scriptBase'
     ]
     flagOptions settings, [
-      'autostore'
+      'doNotStore'
       'imagesOnly'
       'multiple'
       'clearable'

--- a/app/assets/javascripts/uploadcare/utils/warnings.js.coffee
+++ b/app/assets/javascripts/uploadcare/utils/warnings.js.coffee
@@ -24,13 +24,6 @@ namespace 'uploadcare.utils', (ns) ->
       ns.warn(msg)
 
   common =
-    autostore: """
-      You have enabled autostore in the widget, but not on the server.
-      To use autostore, make sure it's enabled in project settings.
-
-      https://uploadcare.com/accounts/settings/
-      """
-
     publicKey: """
       Global public key not set. Uploads may not work!
       Add this to the <head> tag to set your key:


### PR DESCRIPTION
Теперь стор в подавляющем большинстве случаев будет браться из настроек проекта. По-моему это решает вообще все проблемы:

— Не просто не делаем еще одну настройку обязательной, а вообще убираем.
— Больше не будет ситуации, когда файлы не загружаются, потому что в проекте одни настройки, а в виджете другие
— Файлы не удаляются у тех, кто не настроил виджет правильно, настраивать нечего.
— Стор включен по умолчанию, как Дима хотел.
— Добавляется еще одна настройка — DO_NOT_STORE, для тех полутора извращенцев, у которых включен стор в проекте, но они не хотят сторить из виджета. В документации ее можно засунуть в самый конец, нормальные люди не должны о ней случайно узнать.

Высосанный из пальца минус только один — придется править документацию и бэкэнд.