### PR TITLE
Hide camera tabs on mobile devices

### DIFF
--- a/app/assets/stylesheets/uploadcare/dialog-mobile.css.scss
+++ b/app/assets/stylesheets/uploadcare/dialog-mobile.css.scss
@@ -143,6 +143,11 @@ $dialog-mobile-min-width: 310px;
 
     // § Camera tab
 
+    // enhance selector specificity
+    .uploadcare-dialog-opened-tabs
+    .uploadcare-dialog-tab.uploadcare-dialog-tab-camera {
+      display: none;
+    }
     .uploadcare-dialog-camera-holder {
       height: auto;
     }


### PR DESCRIPTION
При этом конечно нет уверенности, что если у человека маленький экран, то у него будет камера в обычном диалоге выбора. Ну и на планшетах, где тоже есть проблема с html5 камерой вкладка никуда не девается.