### PR TITLE
Generate module with window and jQuery checking

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,8 +46,8 @@ def file_list(path)
     .map { |f| [f, File.basename(f), File.basename(f, '.*'), File.extname(f)] }
 end
 
-PACKAGES = ['uploadcare', 'uploadcare.full', 'uploadcare.ie8', 'uploadcare.api',
-            'uploadcare.lang.en']
+PACKAGES = ['uploadcare.api', 'uploadcare.lang.en', 'uploadcare',
+            'uploadcare.full', 'uploadcare.ie8']
 
 IMAGES_TYPES = {
   '.png' => 'image/png',
@@ -90,7 +90,7 @@ def build_widget(version)
 
   def wrap_namespace(js)
     wrapper = Rails.application.assets["uploadcare/build/wrapper.js"].source
-    wrapper.sub('___widget_code___', js)
+    wrapper.sub("___widget_code___") {|_| js }
   end
 
   uglifier = Uglifier.new({

--- a/Rakefile
+++ b/Rakefile
@@ -120,7 +120,13 @@ def build_widget(version)
     },
   })
 
-  PACKAGES.each do |package|
+  if ENV['PACKAGES']
+    packages = ENV['PACKAGES'].split(',')
+  else
+    packages = PACKAGES
+  end
+
+  packages.each do |package|
     js = Rails.application.assets["uploadcare/build/#{package}.coffee"].source
     if PACKAGES_WITH_JQUERY.include?(package)
         js = wrap_namespace_with_jquery(js, version)
@@ -128,8 +134,10 @@ def build_widget(version)
         js = wrap_namespace(js, version)
     end
     write_file("#{version}/#{package}.js", header + js)
-    minified = uglifier.compile(js)
-    write_file("#{version}/#{package}.min.js", header + minified)
+    if not ENV['NO_MINIFY']
+      minified = uglifier.compile(js)
+      write_file("#{version}/#{package}.min.js", header + minified)
+    end
   end
 
   IMAGES.each do |full, base|

--- a/Rakefile
+++ b/Rakefile
@@ -91,11 +91,11 @@ def build_widget(version)
   eos
 
   def wrap_namespace(js, version)
-    ";(function(uploadcare, SCRIPT_BASE, global){\nif(typeof global.document === \"undefined\") return;\nvar __exports;\n__exports = {};\nif (typeof module === \"object\" && typeof module.exports === \"object\") {\nmodule.exports = __exports;\njQuery = (typeof global.jQuery !== \"undefined\") ? global.jQuery : require(\"jquery\");\n} else {\nif(typeof global.jQuery === \"undefined\") throw new Error(\"Uploadcare need jQuery\");\nglobal.uploadcare = __exports;\n}\n(function(window, jQuery, __exports){\n#{js}}(global, jQuery, __exports));}({}, '//ucarecdn.com/widget/#{version}/uploadcare/', typeof window !== \"undefined\" ? window : this));"
+    ";(function(uploadcare, SCRIPT_BASE, global){\nif(typeof global.document === \"undefined\") return;\nvar __exports;\n__exports = {};\nif (typeof module === \"object\" && typeof module.exports === \"object\") {\nmodule.exports = __exports;\njQuery = (typeof global.jQuery !== \"undefined\") ? global.jQuery : require(\"jquery\");\n} else {\nif(typeof global.jQuery === \"undefined\") throw new Error(\"Uploadcare need jQuery\");\nglobal.uploadcare = __exports;\n}\n(function(window, jQuery, __exports, isModule){\n#{js}}(global, jQuery, __exports, true));}({}, '//ucarecdn.com/widget/#{version}/uploadcare/', typeof window !== \"undefined\" ? window : this));"
   end
 
   def wrap_namespace_with_jquery(js, version)
-    ";(function(uploadcare, SCRIPT_BASE, global){\nif(typeof global.document === \"undefined\") return;\nvar __exports;\n__exports = {};\nif (typeof module === \"object\" && typeof module.exports === \"object\") {\nmodule.exports = __exports;\n} else {\nglobal.uploadcare = __exports;\n}\n(function(window, __exports){\n#{js}}(global, __exports));}({}, '//ucarecdn.com/widget/#{version}/uploadcare/', typeof window !== \"undefined\" ? window : this));"
+    ";(function(uploadcare, SCRIPT_BASE, global){\nif(typeof global.document === \"undefined\") return;\nvar __exports;\n__exports = {};\nif (typeof module === \"object\" && typeof module.exports === \"object\") {\nmodule.exports = __exports;\n} else {\nglobal.uploadcare = __exports;\n}\n(function(window, __exports, isModule){\n#{js}}(global, __exports, true));}({}, '//ucarecdn.com/widget/#{version}/uploadcare/', typeof window !== \"undefined\" ? window : this));"
   end
 
   uglifier = Uglifier.new({

--- a/Rakefile
+++ b/Rakefile
@@ -91,11 +91,11 @@ def build_widget(version)
   eos
 
   def wrap_namespace(js, version)
-    ";(function(uploadcare, SCRIPT_BASE, global){\nif(typeof global.document === \"undefined\") return;\nvar __exports;\n__exports = {};\nif (typeof module === \"object\" && typeof module.exports === \"object\") {\nmodule.exports = __exports;\njQuery = (typeof global.jQuery !== \"undefined\") ? global.jQuery : require(\"jquery\");\n} else {\nif(typeof global.jQuery === \"undefined\") throw new Error(\"Uploadcare need jQuery\");\nglobal.uploadcare = __exports;\n}\n(function(window, jQuery, __exports, isModule){\n#{js}}(global, jQuery, __exports, true));}({}, '//ucarecdn.com/widget/#{version}/uploadcare/', typeof window !== \"undefined\" ? window : this));"
+    ";(function(uploadcare, SCRIPT_BASE, global){\nif(typeof global.document === \"undefined\") return;\nvar moduleExports;\nmoduleExports = {};\nif (typeof module === \"object\" && typeof module.exports === \"object\") {\nmodule.exports = moduleExports;\njQuery = (typeof global.jQuery !== \"undefined\") ? global.jQuery : require(\"jquery\");\n} else {\nif(typeof global.jQuery === \"undefined\") throw new Error(\"Uploadcare need jQuery\");\nglobal.uploadcare = moduleExports;\n}\n(function(window, jQuery, moduleExports, isModule){\n#{js}}(global, jQuery, moduleExports, true));}({}, '//ucarecdn.com/widget/#{version}/uploadcare/', typeof window !== \"undefined\" ? window : this));"
   end
 
   def wrap_namespace_with_jquery(js, version)
-    ";(function(uploadcare, SCRIPT_BASE, global){\nif(typeof global.document === \"undefined\") return;\nvar __exports;\n__exports = {};\nif (typeof module === \"object\" && typeof module.exports === \"object\") {\nmodule.exports = __exports;\n} else {\nglobal.uploadcare = __exports;\n}\n(function(window, __exports, isModule){\n#{js}}(global, __exports, true));}({}, '//ucarecdn.com/widget/#{version}/uploadcare/', typeof window !== \"undefined\" ? window : this));"
+    ";(function(uploadcare, SCRIPT_BASE, global){\nif(typeof global.document === \"undefined\") return;\nvar moduleExports;\nmoduleExports = {};\nif (typeof module === \"object\" && typeof module.exports === \"object\") {\nmodule.exports = moduleExports;\n} else {\nglobal.uploadcare = moduleExports;\n}\n(function(window, moduleExports, isModule){\n#{js}}(global, moduleExports, true));}({}, '//ucarecdn.com/widget/#{version}/uploadcare/', typeof window !== \"undefined\" ? window : this));"
   end
 
   uglifier = Uglifier.new({

--- a/app/assets/javascripts/uploadcare/boot.coffee.erb
+++ b/app/assets/javascripts/uploadcare/boot.coffee.erb
@@ -10,8 +10,3 @@ expose('jQuery')
 
 expose 'plugin', (fn) ->
   fn(uploadcare)
-
-# back compatibility
-expose 'whenReady', (fn) ->
-  fn()
-

--- a/app/assets/javascripts/uploadcare/build/wrapper.js
+++ b/app/assets/javascripts/uploadcare/build/wrapper.js
@@ -10,7 +10,7 @@
     global.uploadcare = factory(global);
   }
 
-}(this, function(window, jQuery) {
+}(typeof window !== "undefined" ? window : this, function(window, jQuery) {
   var uploadcare, document = window.document;
 
 ___widget_code___

--- a/app/assets/javascripts/uploadcare/build/wrapper.js
+++ b/app/assets/javascripts/uploadcare/build/wrapper.js
@@ -1,14 +1,17 @@
 ;(function(global, factory) {
-  // module.exports can be object or function, if jQuery
-  // is already initialized in the same script.
+  // Not a browser enviroment at all: not Browserify/Webpack.
+  if ( ! global.document) {
+    return;
+  }
+
   if (typeof module === "object" && module.exports) {
-    module.exports = factory(global);
+    module.exports = factory(global, require("jquery"));
   } else {
     global.uploadcare = factory(global);
   }
 
-}(this, function(window, noGlobal) {
-  var uploadcare;
+}(this, function(window, jQuery) {
+  var uploadcare, document = window.document;
 
 ___widget_code___
 

--- a/app/assets/javascripts/uploadcare/build/wrapper.js
+++ b/app/assets/javascripts/uploadcare/build/wrapper.js
@@ -1,0 +1,16 @@
+;(function(global, factory) {
+  // module.exports can be object or function, if jQuery
+  // is already initialized in the same script.
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory(global);
+  } else {
+    global.uploadcare = factory(global);
+  }
+
+}(this, function(window, noGlobal) {
+  var uploadcare;
+
+___widget_code___
+
+  return uploadcare.__exports;
+}));

--- a/app/assets/javascripts/uploadcare/namespace.coffee
+++ b/app/assets/javascripts/uploadcare/namespace.coffee
@@ -1,3 +1,7 @@
+if typeof isModule == "undefined"
+  __exports = {}
+  window.uploadcare = __exports
+
 uploadcare.namespace = (path, fn) ->
   target = uploadcare
   if path

--- a/app/assets/javascripts/uploadcare/namespace.coffee
+++ b/app/assets/javascripts/uploadcare/namespace.coffee
@@ -1,10 +1,3 @@
-__exports = {}
-if typeof module == "object" and typeof module.exports == "object"
-  module.exports = __exports
-else
-  window.uploadcare = __exports
-
-
 uploadcare.namespace = (path, fn) ->
   target = uploadcare
   if path

--- a/app/assets/javascripts/uploadcare/namespace.coffee
+++ b/app/assets/javascripts/uploadcare/namespace.coffee
@@ -1,8 +1,10 @@
-if typeof isModule == "undefined"
-  __exports = {}
-  window.uploadcare = __exports
-else
-  __exports = moduleExports;
+# In the devlopment enviroment this will be window.uploadcare.
+# In the release this will be local var in the scope.
+`uploadcare = {}`
+
+
+uploadcare.__exports = {}
+
 
 uploadcare.namespace = (path, fn) ->
   target = uploadcare
@@ -18,7 +20,7 @@ uploadcare.expose = (key, value) ->
   parts = key.split('.')
   last = parts.pop()
 
-  target = __exports
+  target = uploadcare.__exports
   source = uploadcare
 
   for part in parts

--- a/app/assets/javascripts/uploadcare/namespace.coffee
+++ b/app/assets/javascripts/uploadcare/namespace.coffee
@@ -1,6 +1,8 @@
 if typeof isModule == "undefined"
   __exports = {}
   window.uploadcare = __exports
+else
+  __exports = moduleExports;
 
 uploadcare.namespace = (path, fn) ->
   target = uploadcare

--- a/app/assets/javascripts/uploadcare/namespace.coffee
+++ b/app/assets/javascripts/uploadcare/namespace.coffee
@@ -1,9 +1,6 @@
 # In the devlopment enviroment this will be window.uploadcare.
 # In the release this will be local var in the scope.
-`uploadcare = {}`
-
-
-uploadcare.__exports = {}
+`uploadcare = {__exports: {}}`
 
 
 uploadcare.namespace = (path, fn) ->

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -45,7 +45,7 @@ uploadcare.namespace 'settings', (ns) ->
     parallelDirectUploads: 10
     passWindowOpen: false
     # maintain settings
-    scriptBase: if SCRIPT_BASE? then SCRIPT_BASE else ''
+    scriptBase: "//ucarecdn.com/widget/#{uploadcare.version}/uploadcare/"
     debugUploads: false
 
   presets =

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -12,6 +12,9 @@
     <% else %>
         <%= javascript_include_tag "uploadcare/build/uploadcare.full" %>
     <% end %>
+    <script>
+        uploadcare = uploadcare.__exports;
+    </script>
 
     <script>
     var $ = uploadcare.jQuery;

--- a/test/dummy/spec/javascripts/spec.js.coffee
+++ b/test/dummy/spec/javascripts/spec.js.coffee
@@ -7,7 +7,8 @@
 # = require_tree ./
 # = require_tree ./fixtures/data
 
-uploadcare = uploadcare.__exports;
+# FIXME: tests should use uploadcare.__exports like regular dev env.
+
 window.$ = window.jQuery = uploadcare.jQuery
 
 window.UPLOADCARE_PUBLIC_KEY = 'demopublickey'

--- a/test/dummy/spec/javascripts/spec.js.coffee
+++ b/test/dummy/spec/javascripts/spec.js.coffee
@@ -7,6 +7,7 @@
 # = require_tree ./
 # = require_tree ./fixtures/data
 
+uploadcare = uploadcare.__exports;
 window.$ = window.jQuery = uploadcare.jQuery
 
 window.UPLOADCARE_PUBLIC_KEY = 'demopublickey'


### PR DESCRIPTION
I update Rakefile, it generate now for packages **without jQuery** follow:

```javascript
;(function(uploadcare, SCRIPT_BASE, global) {
  if (typeof global.document === "undefined") return;

  var moduleExports;

  moduleExports = {};

  if (typeof module === "object" && typeof module.exports === "object") {
    module.exports = moduleExports;
    jQuery = (typeof global.jQuery !== "undefined") ? global.jQuery : require("jquery");
  } else {
    if (typeof global.jQuery === "undefined") throw new Error("Uploadcare need jQuery");
    global.uploadcare = moduleExports;
  }

  (function(window, jQuery, moduleExports, isModule) {
     // uploadcare code here ...
  }(global, jQuery, moduleExports, true));

}({}, '//ucarecdn.com/widget/latest/uploadcare/', typeof window !== "undefined" ? window : this));
```

For packages **with jQuery** (full and ie8):
```javascript
;(function(uploadcare, SCRIPT_BASE, global) {
  if (typeof global.document === "undefined") return;

  var moduleExports;

  moduleExports = {};

  if (typeof module === "object" && typeof module.exports === "object") {
    module.exports = moduleExports;
  } else {
    global.uploadcare = moduleExports;
  }

  (function(window, moduleExports, isModule) {
     // uploadcare code here ...
  }(global, moduleExports, true));

}({}, '//ucarecdn.com/widget/latest/uploadcare/', typeof window !== "undefined" ? window : this));
```