### PR TITLE
Destroy

### DIFF
--- a/app/assets/javascripts/uploadcare/build/_widget.coffee
+++ b/app/assets/javascripts/uploadcare/build/_widget.coffee
@@ -15,6 +15,7 @@
 expose('globals', uploadcare.settings.common)
 expose('start')
 expose('initialize')
+expose('reset')
 expose('fileFrom')
 expose('filesFrom')
 expose('FileGroup')

--- a/app/assets/javascripts/uploadcare/widget/base-widget.coffee
+++ b/app/assets/javascripts/uploadcare/widget/base-widget.coffee
@@ -135,7 +135,7 @@ uploadcare.namespace 'widget', (ns) ->
         
     destroy: () ->
       @template.content.remove();
-      @template.element.data('uploadcareWidget', null)
+      @element.data('uploadcareWidget', null).off('.uploadcare')
       return
 
     api: ->

--- a/app/assets/javascripts/uploadcare/widget/base-widget.coffee
+++ b/app/assets/javascripts/uploadcare/widget/base-widget.coffee
@@ -132,6 +132,10 @@ uploadcare.namespace 'widget', (ns) ->
         dialogApi = uploadcare.openDialog(@currentObject, tab, @settings)
         @__onDialogOpen.fire(dialogApi)
         return dialogApi.done(@__setObject)
+        
+    destroy: () ->
+      @template.content.remove();
+      @template.element.data('uploadcareWidget', null)
 
     api: ->
       if not @__api
@@ -139,7 +143,8 @@ uploadcare.namespace 'widget', (ns) ->
           'openDialog'
           'reloadInfo'
           'value'
-          'validators'
+          'validators',
+          'destroy'
         ])
         @__api.onChange = utils.publicCallbacks(@__onChange)
         @__api.onUploadComplete = utils.publicCallbacks(@__onUploadComplete)

--- a/app/assets/javascripts/uploadcare/widget/base-widget.coffee
+++ b/app/assets/javascripts/uploadcare/widget/base-widget.coffee
@@ -136,6 +136,7 @@ uploadcare.namespace 'widget', (ns) ->
     destroy: () ->
       @template.content.remove();
       @template.element.data('uploadcareWidget', null)
+      return
 
     api: ->
       if not @__api

--- a/app/assets/javascripts/uploadcare/widget/live.coffee
+++ b/app/assets/javascripts/uploadcare/widget/live.coffee
@@ -69,6 +69,12 @@ uploadcare.namespace '', (ns) ->
       setInterval(ns.initialize, 100)
     # should be after settings.common(s) call
     ns.initialize()
+    
+  ns.reset = (container = ':root') ->
+    $(selector).each () ->
+      widget = $(this).data(dataAttr)
+      if(widget)
+        widget.destroy()
 
   $ ->
     if not window["UPLOADCARE_MANUAL_START"]

--- a/test/dummy/app/views/welcome/with_value.html.erb
+++ b/test/dummy/app/views/welcome/with_value.html.erb
@@ -50,8 +50,12 @@
 <p>Group incorrect:<br>
   <input type="text" data-public-key="1c86ca998ba22e75fbc6" role="uploadcare-uploader" name="GroupIncorrect"
          value="cd334b26-c641-4393-bcce-b5041546430d~" data-images-only="" data-multiple="true"/>
-  <button>Clear</button>
+  <button>Clear</button></p>
 
+
+<input type="text" size="30" id="test-memory">
+<br>
+<button id="test-memory-run">Run memory test!</button>
 
 <script>
   UPLOADCARE_CLEARABLE = true;
@@ -74,4 +78,24 @@
       }
     });
   });
+
+  var memoryTestInterval = null;
+
+  $('#test-memory-run').on('click', function() {
+    if (memoryTestInterval) {
+      clearInterval(memoryTestInterval);
+      memoryTestInterval = null;
+      $(this).text('Run memory test!');
+      return;
+    }
+
+    memoryTestInterval = setInterval(function() {
+      var N = 100;
+      for (var i = 0; i < N; i++) {
+        uploadcare.Widget('#test-memory').destroy();
+      }
+    }, 500);
+    $(this).text('Stop memory test');
+  });
+
 </script>


### PR DESCRIPTION
I added the destroy method to the widget. This method remove an element `uploadcare-widget` from DOM and flush a uploadcare's data in the input element. 

But we have a problem 😣. If uploadcare initialized on the default input with `role="uploadcare-uploader`, after `uploadcare-widget` will be removed, it returns anyway. Because [`live` is true](https://uploadcare.com/documentation/widget/#initialization) and uploadcare initialized as a widget after about ~100 ms. So, we need set `UPLOADCARE_LIVE = false;`.
#### Example 1

``` html
<input className="hey" id="hey" />
<button onClick="removeHey()">Exterminate!</button>
```

``` javascript
let widget = uploadcare.Widget("#hey");

removeHey() {
  widget.destroy();
}
```
#### Example 2

doesn't work, because live = true

``` html
<input role="uploadcare-uploader" id="hey1" />
<input role="uploadcare-uploader" id="hey2" />
<input role="uploadcare-uploader" id="hey3" />
<button onClick="removeHey2()">Exterminate!</button>
```

``` javascript
removeHey2() {
  let widget = uploadcare.Widget("#hey2");
  widget.destroy();
}
```
#### Example 3

``` javascript
UPLOADCARE_LIVE = false;
```

``` html
<input role="uploadcare-uploader" id="hey1" />
<input role="uploadcare-uploader" id="hey2" />
<input role="uploadcare-uploader" id="hey3" />
<button onClick="removeHey2()">Exterminate!</button>
```

``` javascript
removeHey2() {
  let widget = uploadcare.Widget("#hey2");
  widget.destroy();
}
```

Related with #328
