### PR TITLE
History and dialog

### DIFF
--- a/app/assets/javascripts/uploadcare/widget/dialog.coffee
+++ b/app/assets/javascripts/uploadcare/widget/dialog.coffee
@@ -33,6 +33,9 @@ uploadcare.namespace '', (ns) ->
         # close only topmost dialog
         currentDialogPr?.reject()
 
+  $(window).on 'popstate', () ->
+    ns.closeDialog()
+
   currentDialogPr = null
   openedClass = 'uploadcare-dialog-opened'
 


### PR DESCRIPTION
I added event `popstate` handler for `window`. Then user press back or forward button in the browser, hire `uploadcare.closeDialog`. Btw @homm how to cancel uploading?

Usage examples:
- https://github.com/Zmoki/try-uploadcare-widget/tree/history
- https://github.com/Zmoki/try-uploadcare-widget/tree/history-router

Fix #340 
