### PR TITLE
Disable imageSmoothingQuality in Chrome due to worst quality

### DIFF
--- a/app/assets/javascripts/uploadcare/utils/image-processor.coffee
+++ b/app/assets/javascripts/uploadcare/utils/image-processor.coffee
@@ -129,7 +129,8 @@ uploadcare.namespace 'utils.image', (ns) ->
       df.resolve(canvas)
 
     cx = document.createElement('canvas').getContext('2d')
-    if 'imageSmoothingQuality' of cx
+    isChrome = navigator.userAgent.match(/\ Chrome\//)
+    if 'imageSmoothingQuality' of cx and not isChrome
       runNative()
     else
       run()


### PR DESCRIPTION
From left to right:
 - experimental `imageSmoothingQuality = 'high'` in Chrome
 - `imageSmoothingQuality = 'high'` in Safari
 - old method without `imageSmoothingQuality` in Chrome

![download-3](https://cloud.githubusercontent.com/assets/128982/15856902/7d46658a-2cc9-11e6-8042-ccd6b938d88e.jpg) ![unknown](https://cloud.githubusercontent.com/assets/128982/15856904/7d752c9e-2cc9-11e6-8521-260d9e2e7f94.jpeg) ![mandril](https://cloud.githubusercontent.com/assets/128982/15856903/7d746598-2cc9-11e6-9e3f-dcd301ca9a38.jpg)