### PR TITLE
Fix active tab border

### DIFF
--- a/app/assets/stylesheets/uploadcare/dialog.scss
+++ b/app/assets/stylesheets/uploadcare/dialog.scss
@@ -123,7 +123,6 @@ html.uploadcare-dialog-opened {
   margin-left: -$dialog-tab-width;
   float: left;
   background: $dialog-body-shadow-color;
-  border-right: 1px solid $dialog-body-border-color;
   overflow: hidden;
 
   .uploadcare-panel-hide-tabs & {
@@ -136,7 +135,8 @@ html.uploadcare-dialog-opened {
     box-sizing: border-box;
     height: 56px;
     position: relative;
-    border-bottom: 1px solid $dialog-body-border-color;
+    border: 1px solid $dialog-body-border-color;
+    border-width: 0 1px 1px 0;
     cursor: pointer;
 
     // Geometry
@@ -174,7 +174,6 @@ html.uploadcare-dialog-opened {
     }
   }
     .uploadcare-dialog-tab_current {
-      margin-right: -1px;
       border-right: 1px solid $dialog-body-background-color;
       &,
       &:hover {


### PR DESCRIPTION
2.10.1:

<img width="164" alt="screen shot 2016-11-02 at 16 14 08" src="https://cloud.githubusercontent.com/assets/128982/19930069/b6cccf16-a117-11e6-9874-103d1ac41098.png">

Fixed:

<img width="152" alt="screen shot 2016-11-02 at 16 15 44" src="https://cloud.githubusercontent.com/assets/128982/19930072/bd4de118-a117-11e6-949f-071669c1999c.png">
