### PR TITLE
Add `contentWindow` check before sending message in iframe

### DIFF
--- a/app/assets/javascripts/uploadcare/widget/tabs/remote-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/remote-tab.coffee
@@ -29,7 +29,7 @@ uploadcare.namespace 'widget.tabs', (ns) ->
       )
 
     __sendMessage: (messageObj) ->
-      @iframe?[0].contentWindow.postMessage(JSON.stringify(messageObj), '*')
+      @iframe?[0].contentWindow?.postMessage(JSON.stringify(messageObj), '*')
 
     __createIframe: =>
       if @iframe


### PR DESCRIPTION
We can send post message to iframe before content will load (for example, internet connection is slow). So, `contentWindow` can be `null` and throw error.