### PR TITLE
Use `op` instead `this` in deferred obj

### DIFF
--- a/app/assets/javascripts/uploadcare/utils/image-processor.coffee
+++ b/app/assets/javascripts/uploadcare/utils/image-processor.coffee
@@ -35,7 +35,7 @@ uploadcare.namespace 'utils.image', (ns) ->
 
         ns.getExif(file).always (exif) ->
           df.notify(.2)
-          isJPEG = @state() is 'resolved'
+          isJPEG = op.state() is 'resolved'
 
           # start = new Date()
           op = ns.shrinkImage(img, settings)


### PR DESCRIPTION
Since jQuery 3 `.resolve`, `.reject`, and `.notify`
now set undefined context instead of using the promise
of the Deferred object with which they are associated

Fixed #387