### PR TITLE
Fix camera tab

### DIFF
--- a/app/assets/javascripts/uploadcare/templates/tab-camera-capture.jst.ejs
+++ b/app/assets/javascripts/uploadcare/templates/tab-camera-capture.jst.ejs
@@ -1,10 +1,16 @@
 <div class="uploadcare--tab__content">
-  <div class="uploadcare--text uploadcare--text_size_large uploadcare--tab__title"><%- t('dialog.tabs.camera.title') %></div>
+  <div class="uploadcare--text uploadcare--text_size_large uploadcare--tab__title">
+    <%- t('dialog.tabs.camera.title') %>
+  </div>
 
-  <button type="button" class="uploadcare--button uploadcare--button_size_big uploadcare--button_primary uploadcare--camera-capture__photo">
-    Take photo
-  </button>
-  <button type="button" class="uploadcare--button uploadcare--button_size_big uploadcare--button_primary uploadcare--camera-capture__video">
-    Take video
-  </button>
+  <div class="uploadcare--camera__controls">
+    <button type="button"
+            class="uploadcare--button uploadcare--button_size_big uploadcare--button_primary uploadcare--camera__button uploadcare--camera__button_type_photo">
+      <%- t('dialog.tabs.camera.capture') %>
+    </button>
+    <button type="button"
+            class="uploadcare--button uploadcare--button_size_big uploadcare--button_primary uploadcare--camera__button uploadcare--camera__button_type_video">
+      <%- t('dialog.tabs.camera.startRecord') %>
+    </button>
+  </div>
 </div>

--- a/app/assets/javascripts/uploadcare/templates/tab-camera-capture.jst.ejs
+++ b/app/assets/javascripts/uploadcare/templates/tab-camera-capture.jst.ejs
@@ -1,0 +1,10 @@
+<div class="uploadcare--tab__content">
+  <div class="uploadcare--text uploadcare--text_size_large uploadcare--tab__title"><%- t('dialog.tabs.camera.title') %></div>
+
+  <button type="button" class="uploadcare--button uploadcare--button_size_big uploadcare--button_primary uploadcare--camera-capture__photo">
+    Take photo
+  </button>
+  <button type="button" class="uploadcare--button uploadcare--button_size_big uploadcare--button_primary uploadcare--camera-capture__video">
+    Take video
+  </button>
+</div>

--- a/app/assets/javascripts/uploadcare/utils.coffee
+++ b/app/assets/javascripts/uploadcare/utils.coffee
@@ -210,7 +210,7 @@ uploadcare.namespace 'utils', (ns) ->
           left: e.pageX - left - width + 10
           top: e.pageY - top - 10
 
-  ns.fileSelectDialog = (container, settings, fn) ->
+  ns.fileSelectDialog = (container, settings, fn, attributes = {}) ->
     accept = settings.inputAcceptTypes
     if accept is ''
       accept = if settings.imagesOnly
@@ -224,6 +224,7 @@ uploadcare.namespace 'utils', (ns) ->
         '<input type="file">'
     )
       .attr('accept', accept)
+      .attr(attributes)
       .css(
         position: 'fixed'
         bottom: 0

--- a/app/assets/javascripts/uploadcare/widget/tabs/camera-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/camera-tab.coffee
@@ -15,6 +15,22 @@ uploadcare.namespace 'widget.tabs', (ns) ->
         @dialogApi.hideTab(@name)
         return
 
+      if @__checkCapture()
+        @container.append(tpl('tab-camera-capture'))
+        @container.addClass('uploadcare--camera-capture')
+        handleFiles = (input) =>
+          @dialogApi.addFiles('object', input.files)
+          @dialogApi.switchTab('preview')
+        fileButton = @container.find('.uploadcare--camera-capture__photo')
+        fileButton.on 'click', =>
+          utils.fileSelectDialog @container, {inputAcceptTypes: 'image/*'}, handleFiles, {capture: 'camera'}
+        fileButton = @container.find('.uploadcare--camera-capture__video')
+        fileButton.on 'click', =>
+          utils.fileSelectDialog @container, {inputAcceptTypes: 'video/*'}, handleFiles, {capture: 'camera'}
+      else
+        @__initCamera()
+
+    __initCamera: ->
       @__loaded = false
       @mirrored = true
 
@@ -59,6 +75,11 @@ uploadcare.namespace 'widget.tabs', (ns) ->
         utils.warn('Camera is not allowed for HTTP. Please use HTTPS connection.');
       isLocalhost = document.location.hostname == 'localhost'
       return !! @getUserMedia and Uint8Array and (isSecure or isLocalhost)
+
+    __checkCapture: () ->
+      input = document.createElement('input')
+      input.setAttribute('capture', true)
+      return !! input.capture
 
     __setState: (newState) =>
       oldStates = ['', 'ready', 'requested', 'denied', 'not-founded',

--- a/app/assets/javascripts/uploadcare/widget/tabs/camera-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/camera-tab.coffee
@@ -15,7 +15,9 @@ uploadcare.namespace 'widget.tabs', (ns) ->
         @container.append(tpl('tab-camera-capture'))
         @container.addClass('uploadcare--camera')
         @container.find('.uploadcare--camera__button_type_photo').on('click', @__captureInput('image/*'))
-        @container.find('.uploadcare--camera__button_type_video').on('click', @__captureInput('video/*'))
+        video = @container.find('.uploadcare--camera__button_type_video').on('click', @__captureInput('video/*'))
+        if @settings.imagesOnly
+          video.hide()
       else
         if not @__checkCompatibility()
           @dialogApi.hideTab(@name)

--- a/app/assets/javascripts/uploadcare/widget/tabs/camera-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/camera-tab.coffee
@@ -11,10 +11,6 @@ uploadcare.namespace 'widget.tabs', (ns) ->
   class ns.CameraTab
 
     constructor: (@container, @tabButton, @dialogApi, @settings, @name) ->
-      if not @__checkCompatibility()
-        @dialogApi.hideTab(@name)
-        return
-
       if @__checkCapture()
         @container.append(tpl('tab-camera-capture'))
         @container.addClass('uploadcare--camera')
@@ -28,6 +24,9 @@ uploadcare.namespace 'widget.tabs', (ns) ->
         fileButton.on 'click', =>
           utils.fileSelectDialog @container, {inputAcceptTypes: 'video/*'}, handleFiles, {capture: 'camera'}
       else
+        if not @__checkCompatibility()
+          @dialogApi.hideTab(@name)
+          return
         @__initCamera()
 
     __initCamera: ->

--- a/app/assets/javascripts/uploadcare/widget/tabs/camera-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/camera-tab.coffee
@@ -14,20 +14,20 @@ uploadcare.namespace 'widget.tabs', (ns) ->
       if @__checkCapture()
         @container.append(tpl('tab-camera-capture'))
         @container.addClass('uploadcare--camera')
-        handleFiles = (input) =>
-          @dialogApi.addFiles('object', input.files)
-          @dialogApi.switchTab('preview')
-        fileButton = @container.find('.uploadcare--camera__button_type_photo')
-        fileButton.on 'click', =>
-          utils.fileSelectDialog @container, {inputAcceptTypes: 'image/*'}, handleFiles, {capture: 'camera'}
-        fileButton = @container.find('.uploadcare--camera__button_type_video')
-        fileButton.on 'click', =>
-          utils.fileSelectDialog @container, {inputAcceptTypes: 'video/*'}, handleFiles, {capture: 'camera'}
+        @container.find('.uploadcare--camera__button_type_photo').on('click', @__captureInput('image/*'))
+        @container.find('.uploadcare--camera__button_type_video').on('click', @__captureInput('video/*'))
       else
         if not @__checkCompatibility()
           @dialogApi.hideTab(@name)
           return
         @__initCamera()
+
+    __captureInput: (accept) =>
+      => utils.fileSelectDialog @container, {inputAcceptTypes: accept}, @__captureInputHandle, {capture: 'camera'}
+
+    __captureInputHandle: (input) =>
+      @dialogApi.addFiles('object', input.files)
+      @dialogApi.switchTab('preview')
 
     __initCamera: ->
       @__loaded = false

--- a/app/assets/javascripts/uploadcare/widget/tabs/camera-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/camera-tab.coffee
@@ -17,14 +17,14 @@ uploadcare.namespace 'widget.tabs', (ns) ->
 
       if @__checkCapture()
         @container.append(tpl('tab-camera-capture'))
-        @container.addClass('uploadcare--camera-capture')
+        @container.addClass('uploadcare--camera')
         handleFiles = (input) =>
           @dialogApi.addFiles('object', input.files)
           @dialogApi.switchTab('preview')
-        fileButton = @container.find('.uploadcare--camera-capture__photo')
+        fileButton = @container.find('.uploadcare--camera__button_type_photo')
         fileButton.on 'click', =>
           utils.fileSelectDialog @container, {inputAcceptTypes: 'image/*'}, handleFiles, {capture: 'camera'}
-        fileButton = @container.find('.uploadcare--camera-capture__video')
+        fileButton = @container.find('.uploadcare--camera__button_type_video')
         fileButton.on 'click', =>
           utils.fileSelectDialog @container, {inputAcceptTypes: 'video/*'}, handleFiles, {capture: 'camera'}
       else

--- a/app/assets/javascripts/uploadcare/widget/tabs/camera-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/camera-tab.coffee
@@ -79,7 +79,7 @@ uploadcare.namespace 'widget.tabs', (ns) ->
 
     __checkCapture: () ->
       input = document.createElement('input')
-      input.setAttribute('capture', true)
+      input.setAttribute('capture', 'camera')
       return !! input.capture
 
     __setState: (newState) =>


### PR DESCRIPTION
Now, if the device and the browser support the `capture` attribute for `input[type=file]`, instead of the video element, two buttons are displayed, "record video" and "take a photo", which give direct access to the camera.

`capture` supported

* on iOS, now on iOS you can on this tab video record, not only the photo
* on androids 4.4 and above, in standard browsers, chrome, opera, uc browser, samsung browser

not supported

* on all decks
* in firefox
* ie mobile