### PR TITLE
Add User Agent for all requests to Upload API

### DIFF
--- a/app/assets/javascripts/uploadcare/files/base.coffee
+++ b/app/assets/javascripts/uploadcare/files/base.coffee
@@ -66,11 +66,13 @@ namespace 'files', (ns) ->
             timeout += 50
 
     __updateInfo: =>
-      utils.jsonp "#{@settings.urlBase}/info/",
+      utils.jsonp("#{@settings.urlBase}/info/", 'GET', {
           jsonerrors: 1
           file_id: @fileId
           pub_key: @settings.publicKey
           wait_is_ready: +@onInfoReady.fired()
+        },
+        headers: {'X-UC-User-Agent': @settings._userAgent})
         .fail (reason) =>
           if @settings.debugUploads
             utils.log("Can't load file info. Probably removed.",

--- a/app/assets/javascripts/uploadcare/files/base.coffee
+++ b/app/assets/javascripts/uploadcare/files/base.coffee
@@ -66,13 +66,17 @@ namespace 'files', (ns) ->
             timeout += 50
 
     __updateInfo: =>
-      utils.jsonp("#{@settings.urlBase}/info/", 'GET', {
+      utils.jsonp(
+        "#{@settings.urlBase}/info/",
+        'GET',
+        {
           jsonerrors: 1
           file_id: @fileId
           pub_key: @settings.publicKey
           wait_is_ready: +@onInfoReady.fired()
         },
-        headers: {'X-UC-User-Agent': @settings._userAgent})
+        headers: {'X-UC-User-Agent': @settings._userAgent}
+      )
         .fail (reason) =>
           if @settings.debugUploads
             utils.log("Can't load file info. Probably removed.",

--- a/app/assets/javascripts/uploadcare/files/group.coffee
+++ b/app/assets/javascripts/uploadcare/files/group.coffee
@@ -113,12 +113,14 @@ namespace 'files', (ns) ->
       df = $.Deferred()
       if @__fileColl.length()
         @__fileInfosDf.done (infos...) =>
-          utils.jsonp "#{@settings.urlBase}/group/", 'POST',
-            pub_key: @settings.publicKey
-            signature: @settings.secureSignature
-            expire: @settings.secureExpire
-            files: for info in infos
-              "/#{info.uuid}/#{info.cdnUrlModifiers or ''}"
+          utils.jsonp("#{@settings.urlBase}/group/", 'POST', {
+              pub_key: @settings.publicKey
+              signature: @settings.secureSignature
+              expire: @settings.secureExpire
+              files: for info in infos
+                "/#{info.uuid}/#{info.cdnUrlModifiers or ''}"
+            },
+            headers: {'X-UC-User-Agent': @settings._userAgent})
           .fail (reason) =>
             if @settings.debugUploads
               utils.log("Can't create group.", @settings.publicKey, reason)
@@ -160,10 +162,12 @@ namespace '', (ns) ->
     df = $.Deferred()
     id = utils.groupIdRegex.exec(groupIdOrUrl)
     if id
-      utils.jsonp "#{settings.urlBase}/group/info/",
-        jsonerrors: 1
-        pub_key: settings.publicKey
-        group_id: id[0]
+      utils.jsonp("#{settings.urlBase}/group/info/", 'GET', {
+          jsonerrors: 1
+          pub_key: settings.publicKey
+          group_id: id[0]
+        },
+        headers: {'X-UC-User-Agent': @settings._userAgent})
       .fail (reason) =>
         if settings.debugUploads
           utils.log("Can't load group info. Probably removed.",

--- a/app/assets/javascripts/uploadcare/files/group.coffee
+++ b/app/assets/javascripts/uploadcare/files/group.coffee
@@ -113,19 +113,23 @@ namespace 'files', (ns) ->
       df = $.Deferred()
       if @__fileColl.length()
         @__fileInfosDf.done (infos...) =>
-          utils.jsonp("#{@settings.urlBase}/group/", 'POST', {
+          utils.jsonp(
+            "#{@settings.urlBase}/group/",
+            'POST',
+            {
               pub_key: @settings.publicKey
               signature: @settings.secureSignature
               expire: @settings.secureExpire
               files: for info in infos
                 "/#{info.uuid}/#{info.cdnUrlModifiers or ''}"
             },
-            headers: {'X-UC-User-Agent': @settings._userAgent})
-          .fail (reason) =>
-            if @settings.debugUploads
-              utils.log("Can't create group.", @settings.publicKey, reason)
-            df.reject()
-          .done(df.resolve)
+            headers: {'X-UC-User-Agent': @settings._userAgent}
+          )
+            .fail (reason) =>
+              if @settings.debugUploads
+                utils.log("Can't create group.", @settings.publicKey, reason)
+              df.reject()
+            .done(df.resolve)
       else
         df.reject()
       return df.promise()
@@ -162,20 +166,24 @@ namespace '', (ns) ->
     df = $.Deferred()
     id = utils.groupIdRegex.exec(groupIdOrUrl)
     if id
-      utils.jsonp("#{settings.urlBase}/group/info/", 'GET', {
+      utils.jsonp(
+        "#{settings.urlBase}/group/info/",
+        'GET',
+        {
           jsonerrors: 1
           pub_key: settings.publicKey
           group_id: id[0]
         },
-        headers: {'X-UC-User-Agent': @settings._userAgent})
-      .fail (reason) =>
-        if settings.debugUploads
-          utils.log("Can't load group info. Probably removed.",
-                    id[0], settings.publicKey, reason)
-        df.reject()
-      .done (data) ->
-        group = new uc_files.SavedFileGroup(data, settings)
-        df.resolve(group.api())
+        headers: {'X-UC-User-Agent': @settings._userAgent}
+      )
+        .fail (reason) =>
+          if settings.debugUploads
+            utils.log("Can't load group info. Probably removed.",
+                      id[0], settings.publicKey, reason)
+          df.reject()
+        .done (data) ->
+          group = new uc_files.SavedFileGroup(data, settings)
+          df.resolve(group.api())
     else
       df.reject()
     df.promise()

--- a/app/assets/javascripts/uploadcare/files/object.coffee
+++ b/app/assets/javascripts/uploadcare/files/object.coffee
@@ -108,7 +108,10 @@ uploadcare.namespace 'files', (ns) ->
           crossDomain: true
           type: 'POST'
           url: "#{@settings.urlBase}/base/?jsonerrors=1"
-          headers: {'X-PINGOTHER': 'pingpong'}
+          headers: {
+            'X-PINGOTHER': 'pingpong'
+            'X-UC-User-Agent': @settings._userAgent
+          }
           contentType: false # For correct boundary string
           processData: false
           data: formData
@@ -159,7 +162,7 @@ uploadcare.namespace 'files', (ns) ->
         UPLOADCARE_STORE: if @settings.doNotStore then '' else 'auto'
 
       @__autoAbort utils.jsonp(
-         "#{@settings.urlBase}/multipart/start/?jsonerrors=1", 'POST', data
+         "#{@settings.urlBase}/multipart/start/?jsonerrors=1", 'POST', data, {headers: {'X-UC-User-Agent': @settings._userAgent}}
         ).fail (reason) =>
           if @settings.debugUploads
             utils.log("Can't start multipart upload.", reason, data)
@@ -216,6 +219,7 @@ uploadcare.namespace 'files', (ns) ->
                 , false
               xhr
             url: parts[partNo]
+            headers: {'X-UC-User-Agent': @settings._userAgent}
             crossDomain: true
             type: 'PUT'
             processData: false
@@ -249,7 +253,7 @@ uploadcare.namespace 'files', (ns) ->
         uuid: uuid
 
       @__autoAbort utils.jsonp(
-          "#{@settings.urlBase}/multipart/complete/?jsonerrors=1", "POST", data
+          "#{@settings.urlBase}/multipart/complete/?jsonerrors=1", "POST", data, {headers: {'X-UC-User-Agent': @settings._userAgent}}
         ).fail (reason) =>
           if @settings.debugUploads
             utils.log("Can't complete multipart upload.",

--- a/app/assets/javascripts/uploadcare/files/object.coffee
+++ b/app/assets/javascripts/uploadcare/files/object.coffee
@@ -108,10 +108,7 @@ uploadcare.namespace 'files', (ns) ->
           crossDomain: true
           type: 'POST'
           url: "#{@settings.urlBase}/base/?jsonerrors=1"
-          headers: {
-            'X-PINGOTHER': 'pingpong'
-            'X-UC-User-Agent': @settings._userAgent
-          }
+          headers: {'X-UC-User-Agent': @settings._userAgent}
           contentType: false # For correct boundary string
           processData: false
           data: formData
@@ -162,10 +159,14 @@ uploadcare.namespace 'files', (ns) ->
         UPLOADCARE_STORE: if @settings.doNotStore then '' else 'auto'
 
       @__autoAbort utils.jsonp(
-         "#{@settings.urlBase}/multipart/start/?jsonerrors=1", 'POST', data, {headers: {'X-UC-User-Agent': @settings._userAgent}}
-        ).fail (reason) =>
-          if @settings.debugUploads
-            utils.log("Can't start multipart upload.", reason, data)
+         "#{@settings.urlBase}/multipart/start/?jsonerrors=1",
+         'POST',
+         data,
+         {headers: {'X-UC-User-Agent': @settings._userAgent}}
+        )
+          .fail (reason) =>
+            if @settings.debugUploads
+              utils.log("Can't start multipart upload.", reason, data)
 
     uploadParts: (parts, uuid) ->
       progress = []
@@ -253,8 +254,12 @@ uploadcare.namespace 'files', (ns) ->
         uuid: uuid
 
       @__autoAbort utils.jsonp(
-          "#{@settings.urlBase}/multipart/complete/?jsonerrors=1", "POST", data, {headers: {'X-UC-User-Agent': @settings._userAgent}}
-        ).fail (reason) =>
-          if @settings.debugUploads
-            utils.log("Can't complete multipart upload.",
-                      uuid, @settings.publicKey, reason)
+          "#{@settings.urlBase}/multipart/complete/?jsonerrors=1",
+          "POST",
+          data,
+          {headers: {'X-UC-User-Agent': @settings._userAgent}}
+        )
+          .fail (reason) =>
+            if @settings.debugUploads
+              utils.log("Can't complete multipart upload.",
+                        uuid, @settings.publicKey, reason)

--- a/app/assets/javascripts/uploadcare/files/url.coffee
+++ b/app/assets/javascripts/uploadcare/files/url.coffee
@@ -50,7 +50,7 @@ uploadcare.namespace 'files', (ns) ->
         if @apiDeferred.state() != 'pending'
           return
 
-        utils.jsonp("#{@settings.urlBase}/from_url/", data)
+        utils.jsonp("#{@settings.urlBase}/from_url/", 'GET', data, {headers: {'X-UC-User-Agent': @settings._userAgent}})
           .fail (reason) =>
             if @settings.debugUploads
               utils.debug("Can't start upload from URL.", reason, data)
@@ -143,7 +143,7 @@ uploadcare.namespace 'files', (ns) ->
       @interval = null
 
     __updateStatus: ->
-      utils.jsonp(@poolUrl, {@token})
+      utils.jsonp(@poolUrl, 'GET', {@token}, {headers: {'X-UC-User-Agent': @settings._userAgent}})
         .fail (reason) =>
           $(this).trigger('error')
         .done (data) =>

--- a/app/assets/javascripts/uploadcare/files/url.coffee
+++ b/app/assets/javascripts/uploadcare/files/url.coffee
@@ -50,7 +50,12 @@ uploadcare.namespace 'files', (ns) ->
         if @apiDeferred.state() != 'pending'
           return
 
-        utils.jsonp("#{@settings.urlBase}/from_url/", 'GET', data, {headers: {'X-UC-User-Agent': @settings._userAgent}})
+        utils.jsonp(
+          "#{@settings.urlBase}/from_url/",
+          'GET',
+          data,
+          {headers: {'X-UC-User-Agent': @settings._userAgent}}
+        )
           .fail (reason) =>
             if @settings.debugUploads
               utils.debug("Can't start upload from URL.", reason, data)
@@ -143,7 +148,12 @@ uploadcare.namespace 'files', (ns) ->
       @interval = null
 
     __updateStatus: ->
-      utils.jsonp(@poolUrl, 'GET', {@token}, {headers: {'X-UC-User-Agent': @settings._userAgent}})
+      utils.jsonp(
+        @poolUrl,
+        'GET',
+        {@token},
+        {headers: {'X-UC-User-Agent': @settings._userAgent}}
+      )
         .fail (reason) =>
           $(this).trigger('error')
         .done (data) =>

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -104,7 +104,7 @@ uploadcare.namespace 'settings', (ns) ->
 
   integrationToUserAgent = (settings) ->
     settings['_userAgent'] =
-      "UploadcareWidget/#{version}/#{settings['publicKey']} (Javascript#{
+      "UploadcareWidget/#{version}/#{settings['publicKey']} (JavaScript#{
         if settings['integration'] then "; #{settings['integration']}" else ''
       })"
     settings

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -1,7 +1,8 @@
 {
   expose
   utils,
-  jQuery: $
+  jQuery: $,
+  version
 } = uploadcare
 
 uploadcare.namespace 'settings', (ns) ->
@@ -49,6 +50,7 @@ uploadcare.namespace 'settings', (ns) ->
     # maintain settings
     scriptBase: "//ucarecdn.com/widget/#{uploadcare.version}/uploadcare/"
     debugUploads: false
+    integration: ''
 
   presets =
     tabs:
@@ -98,6 +100,13 @@ uploadcare.namespace 'settings', (ns) ->
   intOptions = (settings, keys) ->
     for key in keys when settings[key]?
       settings[key] = parseInt(settings[key])
+    settings
+
+  integrationToUserAgent = (settings) ->
+    settings['_userAgent'] =
+      "UploadcareWidget/#{version}/#{settings['publicKey']} (Javascript#{
+        if settings['integration'] then "; #{settings['integration']}" else ''
+      })"
     settings
 
   parseCrop = (val) ->
@@ -158,7 +167,8 @@ uploadcare.namespace 'settings', (ns) ->
       'multipartConcurrency'
       'multipartMaxAttempts'
       'parallelDirectUploads'
-    ])
+    ]
+    integrationToUserAgent(settings))
 
     if settings.crop != false and not $.isArray(settings.crop)
       if /^(disabled?|false|null)$/i.test(settings.crop)

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -67,16 +67,13 @@ uploadcare.namespace 'settings', (ns) ->
       all: 'file camera url facebook gdrive gphotos dropbox instagram evernote flickr skydrive box vk huddle'
       default: defaults.tabs
 
-  # settings from data attributes of script tag
+  # integration setting from data attributes of script tag
   script = document.currentScript || do ->
-    scripts = document.getElementsByTagName("script")
+    scripts = document.getElementsByTagName('script')
     scripts[scripts.length - 1]
-  scriptSettings = {}
-  for key of defaults
-    value = $(script).data(key)
-    if value isnt undefined
-      scriptSettings[key] = value
-  defaults = $.extend(defaults, scriptSettings)
+  integration = $(script).data('integration')
+  if integration isnt undefined
+    defaults = $.extend(defaults, {integration})
 
   str2arr = (value) ->
     if not $.isArray(value)

--- a/app/assets/javascripts/uploadcare/utils.coffee
+++ b/app/assets/javascripts/uploadcare/utils.coffee
@@ -266,11 +266,8 @@ uploadcare.namespace 'utils', (ns) ->
     crossDomain: true
     cache: false
 
-  ns.jsonp = (url, type, data) ->
-    if $.isPlainObject(type)
-      data = type
-      type = 'GET'
-    $.ajax($.extend({url, type, data}, ns.ajaxDefaults)).then (data) ->
+  ns.jsonp = (url, type, data, settings = {}) ->
+    $.ajax($.extend({url, type, data}, settings, ns.ajaxDefaults)).then (data) ->
       if data.error
         text = data.error.content or data.error
         $.Deferred().reject(text)


### PR DESCRIPTION
Also add the new option, `integration`, with it you can specify the framework and plugin through which the widget is embedded, e.g. `JotForm; Uploadcare-JotForm/1.0.0`.

The `integration` option used to build the `_userAgent` setting.

The `_userAgent` setting used for every requests to our Upload API.