### PR TITLE
Signed preview urls

### DIFF
--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -152,18 +152,17 @@ uploadcare.namespace 'settings', (ns) ->
   defaultPreviewUrlCallback = (url, info) ->
     if not @previewProxy
       return url
-    
-    encodedUrl = encodeURIComponent(url)
 
-    justAppend = /\=$/.test(@previewProxy)
-    useAmpersand = /[^\&\?\=]$/.test(@previewProxy)
-    addQuestionSign = not /\?/.test(@previewProxy)
+    addQuery = not /\?/.test(@previewProxy)
+    addName = addQuery or not /\=$/.test(@previewProxy)
+    addAmpersand = not addQuery and not /[\&\?\=]$/.test(@previewProxy)
 
-    queryPart = if justAppend then encodedUrl else "url=#{encodedUrl}"
-    if useAmpersand then queryPart = '&' + queryPart
-    if addQuestionSign then queryPart = '?' + queryPart
+    queryPart = encodeURIComponent(url)
+    if addName then queryPart = 'url=' + queryPart
+    if addAmpersand then queryPart = '&' + queryPart
+    if addQuery then queryPart = '?' + queryPart
 
-    utils.normalizeUrl(@previewProxy) + queryPart
+    return @previewProxy + queryPart
 
   normalize = (settings) ->
     arrayOptions(settings, [

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -37,7 +37,7 @@ uploadcare.namespace 'settings', (ns) ->
     cdnBase: 'https://ucarecdn.com'
     urlBase: 'https://upload.uploadcare.com'
     socialBase: 'https://social.uploadcare.com'
-    previewUrlProvider: null
+    previewBase: null
     overridePreviewUrl: null
     # fine tuning
     imagePreviewMaxSize: 25 * 1024 * 1024
@@ -204,11 +204,11 @@ uploadcare.namespace 'settings', (ns) ->
     if settings.validators
       settings.validators = settings.validators.slice()
     
-    if settings.previewUrlProvider and not settings.overridePreviewUrl
+    if settings.previewBase and not settings.overridePreviewUrl
       settings.overridePreviewUrl = (url, info) => 
-        useGetParam = /\?$/.test(settings.previewUrlProvider)
+        useGetParam = /\?$/.test(settings.previewBase)
         location = if useGetParam then "url=#{encodeURIComponent(url)}" else "/#{url}"
-        utils.normalizeUrl(settings.previewUrlProvider) + location
+        utils.normalizeUrl(settings.previewBase) + location
     
     if settings.overridePreviewUrl
       if typeof settings.overridePreviewUrl is 'string'

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -149,6 +149,21 @@ uploadcare.namespace 'settings', (ns) ->
     quality: shrink[3] / 100 if shrink[3]
     size: size
 
+  defaultPreviewUrlCallback = (url, info) ->
+    return url if not @previewProxy
+    
+    encodedUrl = encodeURIComponent(url)
+
+    justAppend = /\=$/.test(@previewProxy)
+    useAmpersand = /[^\&\?\=]$/.test(@previewProxy)
+    addQuestionSign = not /\?/.test(@previewProxy)
+
+    queryPart = if justAppend then encodedUrl else "url=#{encodedUrl}"
+    queryPart = '&'.concat(queryPart) if useAmpersand
+    queryPart = '?'.concat(queryPart) if addQuestionSign
+
+    utils.normalizeUrl(@previewProxy) + queryPart
+
   normalize = (settings) ->
     arrayOptions(settings, [
       'tabs'
@@ -204,19 +219,7 @@ uploadcare.namespace 'settings', (ns) ->
     if settings.validators
       settings.validators = settings.validators.slice()
     
-    if settings.previewProxy and not settings.previewUrlCallback
-      settings.previewUrlCallback = (url, info) ->
-        encodedUrl = encodeURIComponent(url)
-
-        justAppend = /\=$/.test(@previewProxy)
-        useAmpersand = /[^\&\?\=]$/.test(@previewProxy)
-        addQuestionSign = not /\?/.test(@previewProxy)
-
-        queryPart = if justAppend then encodedUrl else "url=#{encodedUrl}"
-        queryPart = '&'.concat(queryPart) if useAmpersand
-        queryPart = '?'.concat(queryPart) if addQuestionSign
-
-        utils.normalizeUrl(@previewProxy) + queryPart
+    settings.previewUrlCallback = defaultPreviewUrlCallback
     
     settings
 

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -37,6 +37,8 @@ uploadcare.namespace 'settings', (ns) ->
     cdnBase: 'https://ucarecdn.com'
     urlBase: 'https://upload.uploadcare.com'
     socialBase: 'https://social.uploadcare.com'
+    previewBase: null
+    previewUrlBuilder: null
     # fine tuning
     imagePreviewMaxSize: 25 * 1024 * 1024
     multipartMinSize: 25 * 1024 * 1024
@@ -201,6 +203,16 @@ uploadcare.namespace 'settings', (ns) ->
 
     if settings.validators
       settings.validators = settings.validators.slice()
+    
+    if settings.previewBase and not settings.previewUrlBuilder
+      settings.previewUrlBuilder = (url, info) => 
+        useGetParam = /\?$/.test(settings.previewBase)
+        location = if useGetParam then "url=#{encodeURIComponent(url)}" else "/#{url}"
+        utils.normalizeUrl(settings.previewBase) + location
+    
+    if settings.previewUrlBuilder
+      if typeof settings.previewUrlBuilder is 'string'
+        settings.previewUrlBuilder = eval(settings.previewUrlBuilder)
 
     settings
 

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -209,11 +209,14 @@ uploadcare.namespace 'settings', (ns) ->
         encodedUrl = encodeURIComponent(url)
         justAppend = /\=$/.test(settings.previewProxy)
         useAmpersand = /[^\&\?]$/.test(settings.previewProxy)
+        addQuestionSign = not /\?/.test(settings.previewProxy)
 
-        queryToAppend = if justAppend then encodedUrl else
+        queryPart = if justAppend then encodedUrl else
           if useAmpersand then "&url=#{encodedUrl}" else "url=#{encodedUrl}"
 
-        utils.normalizeUrl(settings.previewProxy) + queryToAppend
+        queryPart = '?' + queryPart if addQuestionSign
+
+        utils.normalizeUrl(settings.previewProxy) + queryPart
     
     settings
 

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -205,11 +205,11 @@ uploadcare.namespace 'settings', (ns) ->
       settings.validators = settings.validators.slice()
     
     if settings.previewProxy and not settings.previewUrlCallback
-      settings.previewUrlCallback = (url, info) =>
+      settings.previewUrlCallback = (url, info) ->
         encodedUrl = encodeURIComponent(url)
-        justAppend = /\=$/.test(settings.previewProxy)
-        useAmpersand = /[^\&\?]$/.test(settings.previewProxy)
-        addQuestionSign = not /\?/.test(settings.previewProxy)
+        justAppend = /\=$/.test(@previewProxy)
+        useAmpersand = /[^\&\?]$/.test(@previewProxy)
+        addQuestionSign = not /\?/.test(@previewProxy)
 
         queryPart = if justAppend then encodedUrl else
           if useAmpersand then "&url=#{encodedUrl}" else "url=#{encodedUrl}"

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -150,7 +150,8 @@ uploadcare.namespace 'settings', (ns) ->
     size: size
 
   defaultPreviewUrlCallback = (url, info) ->
-    return url if not @previewProxy
+    if not @previewProxy
+      return url
     
     encodedUrl = encodeURIComponent(url)
 
@@ -159,8 +160,8 @@ uploadcare.namespace 'settings', (ns) ->
     addQuestionSign = not /\?/.test(@previewProxy)
 
     queryPart = if justAppend then encodedUrl else "url=#{encodedUrl}"
-    queryPart = '&'.concat(queryPart) if useAmpersand
-    queryPart = '?'.concat(queryPart) if addQuestionSign
+    if useAmpersand then queryPart = '&' + queryPart
+    if addQuestionSign then queryPart = '?' + queryPart
 
     utils.normalizeUrl(@previewProxy) + queryPart
 

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -38,7 +38,7 @@ uploadcare.namespace 'settings', (ns) ->
     urlBase: 'https://upload.uploadcare.com'
     socialBase: 'https://social.uploadcare.com'
     previewBase: null
-    previewUrlBuilder: null
+    resolvePreviewUrl: null
     # fine tuning
     imagePreviewMaxSize: 25 * 1024 * 1024
     multipartMinSize: 25 * 1024 * 1024
@@ -204,15 +204,15 @@ uploadcare.namespace 'settings', (ns) ->
     if settings.validators
       settings.validators = settings.validators.slice()
     
-    if settings.previewBase and not settings.previewUrlBuilder
-      settings.previewUrlBuilder = (url, info) => 
+    if settings.previewBase and not settings.resolvePreviewUrl
+      settings.resolvePreviewUrl = (url, info) => 
         useGetParam = /\?$/.test(settings.previewBase)
         location = if useGetParam then "url=#{encodeURIComponent(url)}" else "/#{url}"
         utils.normalizeUrl(settings.previewBase) + location
     
-    if settings.previewUrlBuilder
-      if typeof settings.previewUrlBuilder is 'string'
-        settings.previewUrlBuilder = eval(settings.previewUrlBuilder)
+    if settings.resolvePreviewUrl
+      if typeof settings.resolvePreviewUrl is 'string'
+        settings.resolvePreviewUrl = eval(settings.resolvePreviewUrl)
 
     settings
 

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -207,11 +207,11 @@ uploadcare.namespace 'settings', (ns) ->
     if settings.previewProxy and not settings.previewUrlCallback
       settings.previewUrlCallback = (url, info) =>
         encodedUrl = encodeURIComponent(url)
-        raw = /\=$/.test(settings.previewProxy)
-        namedNoAmp = /[\&\?]$/.test(settings.previewProxy)
+        justAppend = /\=$/.test(settings.previewProxy)
+        useAmpersand = /[^\&\?]$/.test(settings.previewProxy)
 
-        path = if raw then encodedUrl else
-          if namedNoAmp then "url=#{encodedUrl}" else "&url=#{encodedUrl}"
+        path = if justAppend then encodedUrl else
+          if useAmpersand then "&url=#{encodedUrl}" else "url=#{encodedUrl}"
 
         utils.normalizeUrl(settings.previewProxy) + path
     

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -207,7 +207,13 @@ uploadcare.namespace 'settings', (ns) ->
     if settings.previewProxy and not settings.previewUrlCallback
       settings.previewUrlCallback = (url, info) =>
         encodedUrl = encodeURIComponent(url)
-        utils.normalizeUrl(settings.previewProxy) + encodedUrl
+        namedArg = /\=$/.test(settings.previewProxy)
+        ampersandLast = /\&$/.test(settings.previewProxy)
+
+        path = if namedArg then encodedUrl else
+          (if ampersandLast then "url=#{encodedUrl}" else "&url=#{encodedUrl}")
+
+        utils.normalizeUrl(settings.previewProxy) + path
     
     settings
 

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -38,7 +38,7 @@ uploadcare.namespace 'settings', (ns) ->
     urlBase: 'https://upload.uploadcare.com'
     socialBase: 'https://social.uploadcare.com'
     previewBase: null
-    resolvePreviewUrl: null
+    overridePreviewUrl: null
     # fine tuning
     imagePreviewMaxSize: 25 * 1024 * 1024
     multipartMinSize: 25 * 1024 * 1024
@@ -204,15 +204,15 @@ uploadcare.namespace 'settings', (ns) ->
     if settings.validators
       settings.validators = settings.validators.slice()
     
-    if settings.previewBase and not settings.resolvePreviewUrl
-      settings.resolvePreviewUrl = (url, info) => 
+    if settings.previewBase and not settings.overridePreviewUrl
+      settings.overridePreviewUrl = (url, info) => 
         useGetParam = /\?$/.test(settings.previewBase)
         location = if useGetParam then "url=#{encodeURIComponent(url)}" else "/#{url}"
         utils.normalizeUrl(settings.previewBase) + location
     
-    if settings.resolvePreviewUrl
-      if typeof settings.resolvePreviewUrl is 'string'
-        settings.resolvePreviewUrl = eval(settings.resolvePreviewUrl)
+    if settings.overridePreviewUrl
+      if typeof settings.overridePreviewUrl is 'string'
+        settings.overridePreviewUrl = eval(settings.overridePreviewUrl)
 
     settings
 

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -219,7 +219,8 @@ uploadcare.namespace 'settings', (ns) ->
     if settings.validators
       settings.validators = settings.validators.slice()
     
-    settings.previewUrlCallback = defaultPreviewUrlCallback
+    if settings.previewProxy and not settings.previewUrlCallback
+      settings.previewUrlCallback = defaultPreviewUrlCallback
     
     settings
 

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -210,10 +210,6 @@ uploadcare.namespace 'settings', (ns) ->
         location = if useGetParam then "url=#{encodeURIComponent(url)}" else "/#{url}"
         utils.normalizeUrl(settings.previewBase) + location
     
-    if settings.overridePreviewUrl
-      if typeof settings.overridePreviewUrl is 'string'
-        settings.overridePreviewUrl = eval(settings.overridePreviewUrl)
-
     settings
 
 

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -216,7 +216,7 @@ uploadcare.namespace 'settings', (ns) ->
         queryPart = '&'.concat(queryPart) if useAmpersand
         queryPart = '?'.concat(queryPart) if addQuestionSign
 
-        utils.normalizeUrl(settings.previewProxy) + queryPart
+        utils.normalizeUrl(@previewProxy) + queryPart
     
     settings
 

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -207,14 +207,14 @@ uploadcare.namespace 'settings', (ns) ->
     if settings.previewProxy and not settings.previewUrlCallback
       settings.previewUrlCallback = (url, info) ->
         encodedUrl = encodeURIComponent(url)
+
         justAppend = /\=$/.test(@previewProxy)
-        useAmpersand = /[^\&\?]$/.test(@previewProxy)
+        useAmpersand = /[^\&\?\=]$/.test(@previewProxy)
         addQuestionSign = not /\?/.test(@previewProxy)
 
-        queryPart = if justAppend then encodedUrl else
-          if useAmpersand then "&url=#{encodedUrl}" else "url=#{encodedUrl}"
-
-        queryPart = '?' + queryPart if addQuestionSign
+        queryPart = if justAppend then encodedUrl else "url=#{encodedUrl}"
+        queryPart = '&'.concat(queryPart) if useAmpersand
+        queryPart = '?'.concat(queryPart) if addQuestionSign
 
         utils.normalizeUrl(settings.previewProxy) + queryPart
     

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -207,11 +207,11 @@ uploadcare.namespace 'settings', (ns) ->
     if settings.previewProxy and not settings.previewUrlCallback
       settings.previewUrlCallback = (url, info) =>
         encodedUrl = encodeURIComponent(url)
-        namedArg = /\=$/.test(settings.previewProxy)
-        ampersandLast = /\&$/.test(settings.previewProxy)
+        raw = /\=$/.test(settings.previewProxy)
+        namedNoAmp = /[\&\?]$/.test(settings.previewProxy)
 
-        path = if namedArg then encodedUrl else
-          (if ampersandLast then "url=#{encodedUrl}" else "&url=#{encodedUrl}")
+        path = if raw then encodedUrl else
+          if namedNoAmp then "url=#{encodedUrl}" else "&url=#{encodedUrl}"
 
         utils.normalizeUrl(settings.previewProxy) + path
     

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -210,10 +210,10 @@ uploadcare.namespace 'settings', (ns) ->
         justAppend = /\=$/.test(settings.previewProxy)
         useAmpersand = /[^\&\?]$/.test(settings.previewProxy)
 
-        path = if justAppend then encodedUrl else
+        queryToAppend = if justAppend then encodedUrl else
           if useAmpersand then "&url=#{encodedUrl}" else "url=#{encodedUrl}"
 
-        utils.normalizeUrl(settings.previewProxy) + path
+        utils.normalizeUrl(settings.previewProxy) + queryToAppend
     
     settings
 

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -37,7 +37,7 @@ uploadcare.namespace 'settings', (ns) ->
     cdnBase: 'https://ucarecdn.com'
     urlBase: 'https://upload.uploadcare.com'
     socialBase: 'https://social.uploadcare.com'
-    previewBase: null
+    previewUrlProvider: null
     overridePreviewUrl: null
     # fine tuning
     imagePreviewMaxSize: 25 * 1024 * 1024
@@ -204,11 +204,11 @@ uploadcare.namespace 'settings', (ns) ->
     if settings.validators
       settings.validators = settings.validators.slice()
     
-    if settings.previewBase and not settings.overridePreviewUrl
+    if settings.previewUrlProvider and not settings.overridePreviewUrl
       settings.overridePreviewUrl = (url, info) => 
-        useGetParam = /\?$/.test(settings.previewBase)
+        useGetParam = /\?$/.test(settings.previewUrlProvider)
         location = if useGetParam then "url=#{encodeURIComponent(url)}" else "/#{url}"
-        utils.normalizeUrl(settings.previewBase) + location
+        utils.normalizeUrl(settings.previewUrlProvider) + location
     
     if settings.overridePreviewUrl
       if typeof settings.overridePreviewUrl is 'string'

--- a/app/assets/javascripts/uploadcare/settings.coffee
+++ b/app/assets/javascripts/uploadcare/settings.coffee
@@ -37,8 +37,8 @@ uploadcare.namespace 'settings', (ns) ->
     cdnBase: 'https://ucarecdn.com'
     urlBase: 'https://upload.uploadcare.com'
     socialBase: 'https://social.uploadcare.com'
-    previewBase: null
-    overridePreviewUrl: null
+    previewProxy: null
+    previewUrlCallback: null
     # fine tuning
     imagePreviewMaxSize: 25 * 1024 * 1024
     multipartMinSize: 25 * 1024 * 1024
@@ -204,11 +204,10 @@ uploadcare.namespace 'settings', (ns) ->
     if settings.validators
       settings.validators = settings.validators.slice()
     
-    if settings.previewBase and not settings.overridePreviewUrl
-      settings.overridePreviewUrl = (url, info) => 
-        useGetParam = /\?$/.test(settings.previewBase)
-        location = if useGetParam then "url=#{encodeURIComponent(url)}" else "/#{url}"
-        utils.normalizeUrl(settings.previewBase) + location
+    if settings.previewProxy and not settings.previewUrlCallback
+      settings.previewUrlCallback = (url, info) =>
+        encodedUrl = encodeURIComponent(url)
+        utils.normalizeUrl(settings.previewProxy) + encodedUrl
     
     settings
 

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab-multiple.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab-multiple.coffee
@@ -120,8 +120,8 @@ uploadcare.namespace 'widget.tabs', (ns) ->
       if info.isImage
         cdnURL = "#{info.cdnUrl}-/quality/lightest/-/preview/108x108/"
 
-        if @settings.previewUrlBuilder 
-          cdnURL = @settings.previewUrlBuilder(cdnURL, info)
+        if @settings.resolvePreviewUrl 
+          cdnURL = @settings.resolvePreviewUrl(cdnURL, info)
           
         filePreview = $('<img>')
           .attr('src', cdnURL)

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab-multiple.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab-multiple.coffee
@@ -119,9 +119,7 @@ uploadcare.namespace 'widget.tabs', (ns) ->
 
       if info.isImage
         cdnURL = "#{info.cdnUrl}-/quality/lightest/-/preview/108x108/"
-
-        if @settings.previewUrlCallback 
-          cdnURL = @settings.previewUrlCallback(cdnURL, info)
+        cdnURL = @settings.previewUrlCallback(cdnURL, info)
           
         filePreview = $('<img>')
           .attr('src', cdnURL)

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab-multiple.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab-multiple.coffee
@@ -120,8 +120,8 @@ uploadcare.namespace 'widget.tabs', (ns) ->
       if info.isImage
         cdnURL = "#{info.cdnUrl}-/quality/lightest/-/preview/108x108/"
 
-        if @settings.overridePreviewUrl 
-          cdnURL = @settings.overridePreviewUrl(cdnURL, info)
+        if @settings.previewUrlCallback 
+          cdnURL = @settings.previewUrlCallback(cdnURL, info)
           
         filePreview = $('<img>')
           .attr('src', cdnURL)

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab-multiple.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab-multiple.coffee
@@ -119,7 +119,9 @@ uploadcare.namespace 'widget.tabs', (ns) ->
 
       if info.isImage
         cdnURL = "#{info.cdnUrl}-/quality/lightest/-/preview/108x108/"
-        cdnURL = @settings.previewUrlCallback(cdnURL, info)
+
+        if @settings.previewUrlCallback 
+          cdnURL = @settings.previewUrlCallback(cdnURL, info)
           
         filePreview = $('<img>')
           .attr('src', cdnURL)

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab-multiple.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab-multiple.coffee
@@ -119,6 +119,10 @@ uploadcare.namespace 'widget.tabs', (ns) ->
 
       if info.isImage
         cdnURL = "#{info.cdnUrl}-/quality/lightest/-/preview/108x108/"
+
+        if @settings.previewUrlBuilder 
+          cdnURL = @settings.previewUrlBuilder(cdnURL, info)
+          
         filePreview = $('<img>')
           .attr('src', cdnURL)
           .addClass('uploadcare--file__icon')

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab-multiple.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab-multiple.coffee
@@ -120,8 +120,8 @@ uploadcare.namespace 'widget.tabs', (ns) ->
       if info.isImage
         cdnURL = "#{info.cdnUrl}-/quality/lightest/-/preview/108x108/"
 
-        if @settings.resolvePreviewUrl 
-          cdnURL = @settings.resolvePreviewUrl(cdnURL, info)
+        if @settings.overridePreviewUrl 
+          cdnURL = @settings.overridePreviewUrl(cdnURL, info)
           
         filePreview = $('<img>')
           .attr('src', cdnURL)

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
@@ -55,8 +55,8 @@ uploadcare.namespace 'widget.tabs', (ns) ->
             # 1162x684 is 1.5 size of conteiner
             src += "-/preview/1162x693/-/setfill/ffffff/-/format/jpeg/-/progressive/yes/"
 
-            if @settings.resolvePreviewUrl
-               src = @settings.resolvePreviewUrl(src, info)
+            if @settings.overridePreviewUrl
+               src = @settings.overridePreviewUrl(src, info)
 
             imgInfo = info.originalImageInfo
             @__setState('image', {src, name: info.name, info})

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
@@ -55,8 +55,8 @@ uploadcare.namespace 'widget.tabs', (ns) ->
             # 1162x684 is 1.5 size of conteiner
             src += "-/preview/1162x693/-/setfill/ffffff/-/format/jpeg/-/progressive/yes/"
 
-            if @settings.previewUrlBuilder
-               src = @settings.previewUrlBuilder(src, info)
+            if @settings.resolvePreviewUrl
+               src = @settings.resolvePreviewUrl(src, info)
 
             imgInfo = info.originalImageInfo
             @__setState('image', {src, name: info.name, info})

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
@@ -54,7 +54,9 @@ uploadcare.namespace 'widget.tabs', (ns) ->
             src = info.originalUrl
             # 1162x684 is 1.5 size of conteiner
             src += "-/preview/1162x693/-/setfill/ffffff/-/format/jpeg/-/progressive/yes/"
-            src = @settings.previewUrlCallback(src, info)
+
+            if @settings.previewUrlCallback
+               src = @settings.previewUrlCallback(src, info)
 
             imgInfo = info.originalImageInfo
             @__setState('image', {src, name: info.name, info})

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
@@ -55,8 +55,8 @@ uploadcare.namespace 'widget.tabs', (ns) ->
             # 1162x684 is 1.5 size of conteiner
             src += "-/preview/1162x693/-/setfill/ffffff/-/format/jpeg/-/progressive/yes/"
 
-            if @settings.overridePreviewUrl
-               src = @settings.overridePreviewUrl(src, info)
+            if @settings.previewUrlCallback
+               src = @settings.previewUrlCallback(src, info)
 
             imgInfo = info.originalImageInfo
             @__setState('image', {src, name: info.name, info})

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
@@ -54,9 +54,7 @@ uploadcare.namespace 'widget.tabs', (ns) ->
             src = info.originalUrl
             # 1162x684 is 1.5 size of conteiner
             src += "-/preview/1162x693/-/setfill/ffffff/-/format/jpeg/-/progressive/yes/"
-
-            if @settings.previewUrlCallback
-               src = @settings.previewUrlCallback(src, info)
+            src = @settings.previewUrlCallback(src, info)
 
             imgInfo = info.originalImageInfo
             @__setState('image', {src, name: info.name, info})

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
@@ -54,6 +54,10 @@ uploadcare.namespace 'widget.tabs', (ns) ->
             src = info.originalUrl
             # 1162x684 is 1.5 size of conteiner
             src += "-/preview/1162x693/-/setfill/ffffff/-/format/jpeg/-/progressive/yes/"
+
+            if @settings.previewUrlBuilder
+               src = @settings.previewUrlBuilder(src, info)
+
             imgInfo = info.originalImageInfo
             @__setState('image', {src, name: info.name, info})
             @initImage([imgInfo.width, imgInfo.height], info.cdnUrlModifiers)


### PR DESCRIPTION
Added two settings: `previewUrlProvider` and `overridePreviewUrl`. User can use one of them depending on their needs.

`previewUrlProvider` accepts a url to the user's `Sign API` endpoint, for example `http://domain.com/signUrl?` or just `http://domain.com`. In the first case original preview url will be sent as GET parameter: `http://domain.com/signUrl?url=${url}`, in the second case - as url path: `http://domain.com/${url}`

`overridePreviewUrl` gives the use full control over the preview urls. It accepts a function with signature `(url, fileInfo) => url` so user can completely override preview url as he needs.

If `overridePreviewUrl` is used then `previewUrlProvider` ignored.


Here is the simple example of `Sign API` request handler
```javascript
app.get('/signUrl', (req, res) => {
  const url = req.query.url
  const user = req.user

  if (!user) {
    res.status(403).send('Authorization failed')
    return
  }

  const expire = Math.round(Date.now() / 1000) + 120
  const token = generateToken(url, expire)

  const secureUrl = url + `?token=${token}&expire=${expire}`

  res.redirect(secureUrl)
})
```