### PR TITLE
Hacky fix video seeking on chrome

### DIFF
--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
@@ -128,7 +128,26 @@ uploadcare.namespace 'widget.tabs', (ns) ->
           URL.revokeObjectURL(src)
 
         @__setState('video')
-        @container.find('.uploadcare--preview__video').attr('src', src)
+        videoTag = @container.find('.uploadcare--preview__video')
+
+        # hack to enable seeking due to bug in MediaRecorder API
+        # https://bugs.chromium.org/p/chromium/issues/detail?id=569840
+        seekingRestored = false
+
+        videoTag.on('loadeddata', () ->
+          el = videoTag.get(0)
+          el.currentTime = 360000 # 100 hours
+        )
+        videoTag.on('ended', () ->
+          if seekingRestored then return
+
+          el = videoTag.get(0)
+          el.currentTime = 0
+          seekingRestored = true
+        )
+        # end of hack
+
+        videoTag.attr('src', src)
 
       df.promise()
 

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
@@ -132,18 +132,15 @@ uploadcare.namespace 'widget.tabs', (ns) ->
 
         # hack to enable seeking due to bug in MediaRecorder API
         # https://bugs.chromium.org/p/chromium/issues/detail?id=569840
-        seekingRestored = false
-
         videoTag.on('loadeddata', () ->
           el = videoTag.get(0)
           el.currentTime = 360000 # 100 hours
+          videoTag.off('loadeddata')
         )
         videoTag.on('ended', () ->
-          if seekingRestored then return
-
           el = videoTag.get(0)
           el.currentTime = 0
-          seekingRestored = true
+          videoTag.off('ended')
         )
         # end of hack
 


### PR DESCRIPTION
There is a bug in Chrome MediaRecorder API:
https://bugs.chromium.org/p/chromium/issues/detail?id=569840

It doesn't write video duration to the file header so it's not available util the end of video not reached.
This hack do the following: 
 1. Set `currentTime` to some big value - 360000 seconds (100 hours)
 2. Video player reaches the end of file and determines video duration
 3. Set `currentTime` back to zero
 4. Seeking is now working
