### PR TITLE
Add hack to show video poster on ios safari

### DIFF
--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
@@ -146,6 +146,9 @@ uploadcare.namespace 'widget.tabs', (ns) ->
 
         videoTag.attr('src', src)
 
+        # hack to load first-frame poster on ios safari
+        videoTag.get(0).load()
+
       df.promise()
 
     # error


### PR DESCRIPTION
Safari on iOS don't load first-frame poster for video without `autoplay` attribute.

There are two possible solutions: use `autoplay` or call `video#load()`

Using `autoplay` can cause video auto-playing in some cases described in [Autoplay Policy](https://www.chromium.org/audio-video/autoplay). In the older browsers it will cause auto-playing in all cases. This is not expected behaviour.

So I've used second one. It seems that there is no any side effect.