### PR TITLE
Pause video playback when preview-tab is switched off

### DIFF
--- a/app/assets/javascripts/uploadcare/widget/dialog.coffee
+++ b/app/assets/javascripts/uploadcare/widget/dialog.coffee
@@ -376,6 +376,8 @@ uploadcare.namespace '', (ns) ->
     switchTab: (tab) =>
       if not tab
         return
+
+      @tabs[@currentTab]?.onExit?()
       @currentTab = tab
 
       @panel.find('.uploadcare--panel__menu')

--- a/app/assets/javascripts/uploadcare/widget/dialog.coffee
+++ b/app/assets/javascripts/uploadcare/widget/dialog.coffee
@@ -195,6 +195,8 @@ uploadcare.namespace '', (ns) ->
         @panel.find(".uploadcare--menu__item_tab_#{tab}")
               .toggleClass("uploadcare--menu__item_hidden", not show)
 
+      document.addEventListener('visibilitychange', @__onBrowserTabVisibilityChange)      
+
       if @settings.publicKey
         @__prepareTabs(tab)
       else
@@ -239,6 +241,15 @@ uploadcare.namespace '', (ns) ->
           @switchTab('preview')
       else
         @__resolve()
+
+    __onBrowserTabVisibilityChange: (e) =>
+      visible = e.target.visibilityState == 'visible'
+      tabInstance = @tabs[@currentTab]
+
+      if visible
+        tabInstance?.onShow?()
+      else 
+        tabInstance?.onHide?()
 
     __autoCrop: (files) ->
       if not @settings.crop or not @settings.multiple
@@ -335,6 +346,7 @@ uploadcare.namespace '', (ns) ->
           .text(if files then "(#{files})" else "")
 
     __closePanel: =>
+      document.removeEventListener('visibilitychange', @__onBrowserTabVisibilityChange)
       @panel.replaceWith(@placeholder)
       @content.remove()
 
@@ -377,7 +389,7 @@ uploadcare.namespace '', (ns) ->
       if not tab
         return
 
-      @tabs[@currentTab]?.onExit?()
+      @tabs[@currentTab]?.onHide?()      
       @currentTab = tab
 
       @panel.find('.uploadcare--panel__menu')
@@ -394,6 +406,8 @@ uploadcare.namespace '', (ns) ->
             .removeClass("#{className}_current")
             .filter(".#{className}_name_#{tab}")
             .addClass("#{className}_current")
+
+      @tabs[@currentTab]?.onShow?()
 
       @dfd.notify(tab)
 

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
@@ -258,3 +258,7 @@ uploadcare.namespace 'widget.tabs', (ns) ->
 
       template.remove()
       control.find('>*').eq(0).addClass(currentClass)
+
+    onExit: () =>
+      video = @container.find('.uploadcare--preview__video').get(0)
+      video?.pause()

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
@@ -259,6 +259,16 @@ uploadcare.namespace 'widget.tabs', (ns) ->
       template.remove()
       control.find('>*').eq(0).addClass(currentClass)
 
-    onExit: () =>
+    onHide: () =>
       video = @container.find('.uploadcare--preview__video').get(0)
-      video?.pause()
+
+      if video and not video.paused
+        video.pause()
+        video.autoPaused = true
+
+    onShow: () =>
+      video = @container.find('.uploadcare--preview__video').get(0)
+
+      if video?.paused and video.autoPaused
+        video.play()
+        video.autoPaused = false


### PR DESCRIPTION
Now, on Preview Tab with video, when we switch to another tab (widget tab or browser tab), playback will be paused and resumed when we return back.