### PR TITLE
Fix `dialog.progress` double call

### DIFF
--- a/app/assets/javascripts/uploadcare/widget/dialog.coffee
+++ b/app/assets/javascripts/uploadcare/widget/dialog.coffee
@@ -374,7 +374,7 @@ uploadcare.namespace '', (ns) ->
       @tabs[name] = new TabCls(tabPanel, tabButton, @publicPromise(), @settings, name)
 
     switchTab: (tab) =>
-      if not tab
+      if not tab or @currentTab == tab
         return
       @currentTab = tab
 


### PR DESCRIPTION
Callback `dialog.onTabSwitch` allows user to track widget's tab switching from one to another.

Usage example:

```javascript
dialog.onTabSwitch((newTab, prevTab) => {
  console.log(`Current tab is switched to from "${prevTab}" to "${newTab}"`) 
})
```