### PR TITLE
v4: Initialization that creates Uploaders on a page

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
   "extends": ["uploadcare", "plugin:react/recommended", "plugin:flowtype/recommended"],
   "plugins": ["flowtype"],
   "rules": {
+    "no-param-reassign": "off",
     "react/no-unknown-property": 0,
     "react/display-name": 0
   },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
   "extends": ["uploadcare", "plugin:react/recommended", "plugin:flowtype/recommended"],
   "plugins": ["flowtype"],
   "rules": {
+    "max-statements": ["error", 15],
     "no-param-reassign": "off",
     "react/no-unknown-property": 0,
     "react/display-name": 0

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "dist/uploadcare.esm.js": {
-    "bundled": 36170,
-    "minified": 15821,
-    "gzipped": 6333,
+    "bundled": 11278,
+    "minified": 4643,
+    "gzipped": 2119,
     "treeshaked": {
       "rollup": {
-        "code": 3707,
+        "code": 4475,
         "import_statements": 0
       },
       "webpack": {
-        "code": 6766
+        "code": 5446
       }
     }
   },
   "dist/uploadcare.cjs.js": {
-    "bundled": 36187,
-    "minified": 15834,
-    "gzipped": 6341
+    "bundled": 11293,
+    "minified": 4656,
+    "gzipped": 2126
   },
   "dist/uploadcare.iife.js": {
-    "bundled": 38632,
-    "minified": 14245,
-    "gzipped": 5988
+    "bundled": 11977,
+    "minified": 4503,
+    "gzipped": 2072
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "dist/uploadcare.esm.js": {
-    "bundled": 11923,
-    "minified": 4721,
-    "gzipped": 2153,
+    "bundled": 11938,
+    "minified": 4705,
+    "gzipped": 2149,
     "treeshaked": {
       "rollup": {
-        "code": 4550,
+        "code": 4534,
         "import_statements": 0
       },
       "webpack": {
-        "code": 5521
+        "code": 5505
       }
     }
   },
   "dist/uploadcare.cjs.js": {
-    "bundled": 11938,
-    "minified": 4734,
-    "gzipped": 2159
+    "bundled": 11953,
+    "minified": 4718,
+    "gzipped": 2156
   },
   "dist/uploadcare.iife.js": {
-    "bundled": 12662,
-    "minified": 4578,
-    "gzipped": 2107
+    "bundled": 12677,
+    "minified": 4562,
+    "gzipped": 2099
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "dist/uploadcare.esm.js": {
-    "bundled": 11278,
-    "minified": 4643,
-    "gzipped": 2119,
+    "bundled": 11923,
+    "minified": 4721,
+    "gzipped": 2153,
     "treeshaked": {
       "rollup": {
-        "code": 4475,
+        "code": 4550,
         "import_statements": 0
       },
       "webpack": {
-        "code": 5446
+        "code": 5521
       }
     }
   },
   "dist/uploadcare.cjs.js": {
-    "bundled": 11293,
-    "minified": 4656,
-    "gzipped": 2126
+    "bundled": 11938,
+    "minified": 4734,
+    "gzipped": 2159
   },
   "dist/uploadcare.iife.js": {
-    "bundled": 11977,
-    "minified": 4503,
-    "gzipped": 2072
+    "bundled": 12662,
+    "minified": 4578,
+    "gzipped": 2107
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "dist/uploadcare.esm.js": {
-    "bundled": 11938,
-    "minified": 4705,
-    "gzipped": 2149,
+    "bundled": 11955,
+    "minified": 4712,
+    "gzipped": 2154,
     "treeshaked": {
       "rollup": {
-        "code": 4534,
+        "code": 4541,
         "import_statements": 0
       },
       "webpack": {
-        "code": 5505
+        "code": 5512
       }
     }
   },
   "dist/uploadcare.cjs.js": {
-    "bundled": 11953,
-    "minified": 4718,
-    "gzipped": 2156
+    "bundled": 11970,
+    "minified": 4725,
+    "gzipped": 2160
   },
   "dist/uploadcare.iife.js": {
-    "bundled": 12677,
-    "minified": 4562,
-    "gzipped": 2099
+    "bundled": 12694,
+    "minified": 4569,
+    "gzipped": 2104
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -7,12 +7,9 @@
 </head>
 
 <body>
-  <input type="url" class="uploadcare-uploader" data-crop="2:2 upscale, free" data-multipart-min-size="111" data-public-key='demopublickey' data-tabs='' data-image-shrink="2x2 100%">
+  <input type="url" class="uploadcare-uploader">
   <hr>
   <script src="../dist/uploadcare.iife.js"></script>
-  <script>
-    uploadcare.uploader.init()
-  </script>
 </body>
 
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -18525,8 +18525,7 @@
     "nanoid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.0.tgz",
-      "integrity": "sha512-SG2qscLE3iM4C0CNzGrsAojJHSVHMS1J8NnvJ31P1lH8P0hGHOiafmniNJz6w6q7vuoDlV7RdySlJgtqkFEVtQ==",
-      "dev": true
+      "integrity": "sha512-SG2qscLE3iM4C0CNzGrsAojJHSVHMS1J8NnvJ31P1lH8P0hGHOiafmniNJz6w6q7vuoDlV7RdySlJgtqkFEVtQ=="
     },
     "nanomatch": {
       "version": "1.2.9",
@@ -25778,6 +25777,38 @@
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "dev": true
+        }
+      }
+    },
+    "rollup-plugin-commonjs": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.2.0.tgz",
+      "integrity": "sha512-0RM5U4Vd6iHjL6rLvr3lKBwnPsaVml+qxOGaaNUWN1lSq6S33KhITOfHmvxV3z2vy9Mk4t0g4rNlVaJJsNQPWA==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.5.2",
+        "magic-string": "^0.25.1",
+        "resolve": "^1.8.1",
+        "rollup-pluginutils": "^2.3.3"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.25.1",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
+          "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.1"
+          }
+        },
+        "resolve": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+          "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.5"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "classnames": "github:nd0ut/classnames#true-es-modules",
-    "hyperapp": "^1.2.9"
+    "hyperapp": "^1.2.9",
+    "nanoid": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.5",
@@ -49,7 +50,6 @@
     "jest": "^23.6.0",
     "jest-environment-jsdom": "^23.4.0",
     "jest-environment-jsdom-global": "^1.1.0",
-    "nanoid": "^2.0.0",
     "ngrok": "^3.1.0",
     "parcel-bundler": "^1.10.3",
     "path": "^0.12.7",
@@ -67,6 +67,7 @@
     "rollup-plugin-alias": "^1.4.0",
     "rollup-plugin-analyzer": "^2.1.0",
     "rollup-plugin-babel": "^4.0.3",
+    "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-license": "^0.7.0",
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-postcss": "^1.6.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,7 @@ import postcss from 'rollup-plugin-postcss'
 import {sizeSnapshot} from 'rollup-plugin-size-snapshot'
 import {plugin as analyze} from 'rollup-plugin-analyzer'
 import alias from 'rollup-plugin-alias'
+import commonjs from 'rollup-plugin-commonjs'
 
 const onAnalysis = ({bundleSize}) => {
   const limitBytes = 250e3
@@ -28,6 +29,7 @@ const getPlugins = () =>
       plugins: [],
     }),
     babel(),
+    commonjs({sourceMap: false}),
     license({
       banner: `
       <%= pkg.name %> <%= pkg.version %>

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,19 @@ const Uploader = () => (
   </div>
 )
 
-const createUploader = ($binder) => {
+/**
+ * Creates before the Binder element the new DOM element that contain Uploader.
+ * Saves the id of Uploader to the data attribute of Binder.
+ * If Binder contains the id of existing Uploader, skips creating.
+ *
+ * @param {HTMLElement} $binder – The Binder element.
+ * @returns {(string|null)} – The id of created or existing Uploader.
+ */
+function createUploader($binder: HTMLElement): string | null {
+  if ($binder.dataset.uploaderId && document.getElementById($binder.dataset.uploaderId)) {
+    return $binder.dataset.uploaderId
+  }
+
   const {parentNode} = $binder
 
   if (!parentNode) {
@@ -36,21 +48,29 @@ const createUploader = ($binder) => {
   return uploaderId
 }
 
-const init = ($container: HTMLElement | null = document.body) => {
+/**
+ * Creates as many Uploaders as Binders in the Container element.
+ *
+ * @param {HTMLElement} [$container] – The Container element, by default is body of the page.
+ * @returns {Array<string>} – The list of ids of Uploaders.
+ */
+function init($container: HTMLElement | null = document.body): Array<string> {
   if (!$container) {
     return
   }
 
   const $binders = $container.querySelectorAll(DEFAULT_BINDERS_SELECTOR)
 
-  Array.from($binders).forEach($binder => {
-    if ($binder.dataset.uploaderId && document.getElementById($binder.dataset.uploaderId)) {
-      return
-    }
+  return Array.from($binders)
+    .map($binder => {
+      const uploaderId = createUploader($binder)
 
-    $binder.dataset.uploaderId = createUploader($binder)
-    $binder.hidden = true
-  })
+      $binder.dataset.uploaderId = uploaderId
+      $binder.hidden = true
+
+      return uploaderId
+    })
+    .filter(id => id !== null)
 }
 
 init()

--- a/src/index.js
+++ b/src/index.js
@@ -15,15 +15,19 @@ const Uploader = () => (
   </div>
 )
 
+type BoundUploader = {|
+  id: string,
+|}
+
 /**
  * Creates before the Binder element the new DOM element that contain Uploader.
  * Saves the id of Uploader to the data attribute of Binder.
  * If Binder contains the id of existing Uploader, skips creating.
  *
  * @param {HTMLElement} $binder – The Binder element.
- * @returns {(string|null)} – The id of created or existing Uploader.
+ * @returns {(BoundUploader|null)} – The created or existing Uploader.
  */
-function createUploader($binder: HTMLElement): string | null {
+function createUploader($binder: HTMLElement): BoundUploader | null {
   if ($binder.dataset.uploaderId && document.getElementById($binder.dataset.uploaderId)) {
     return {id: $binder.dataset.uploaderId}
   }
@@ -52,25 +56,24 @@ function createUploader($binder: HTMLElement): string | null {
  * Creates as many Uploaders as Binders in the Container element.
  *
  * @param {HTMLElement} [$container] – The Container element, by default is body of the page.
- * @returns {Array<string>} – The list of ids of Uploaders.
+ * @returns {Array<BoundUploader>} – The list of Uploaders.
  */
-function init($container: HTMLElement | null = document.body): Array<string> {
-  if (!$container) {
-    return
-  }
-
+function init($container?: HTMLElement = document.body): Array<BoundUploader> {
   const $binders = $container.querySelectorAll(DEFAULT_BINDERS_SELECTOR)
 
   return Array.from($binders)
-    .map($binder => {
+    .reduce((uploaders, $binder) => {
       const uploader = createUploader($binder)
+
+      if (uploader === null) {
+        return
+      }
 
       $binder.dataset.uploaderId = uploader.id
       $binder.hidden = true
 
-      return uploader
-    })
-    .filter(id => id !== null)
+      uploaders.push(uploader)
+    }, [])
 }
 
 init()

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ const Uploader = () => (
  */
 function createUploader($binder: HTMLElement): string | null {
   if ($binder.dataset.uploaderId && document.getElementById($binder.dataset.uploaderId)) {
-    return $binder.dataset.uploaderId
+    return {id: $binder.dataset.uploaderId}
   }
 
   const {parentNode} = $binder
@@ -34,18 +34,18 @@ function createUploader($binder: HTMLElement): string | null {
     return null
   }
 
-  const uploaderName = 'uploadcare--uploader'
-  const uploaderId = `${uploaderName}-${nanoid()}`
+  const name = 'uploadcare--uploader'
+  const id = `${name}-${nanoid()}`
   const $uploader = document.createElement('div')
 
-  $uploader.id = uploaderId
-  $uploader.classList.add(uploaderName)
+  $uploader.id = id
+  $uploader.classList.add(name)
 
   parentNode.insertBefore($uploader, $binder)
 
   app(state, actions, Uploader, $uploader)
 
-  return uploaderId
+  return {id}
 }
 
 /**
@@ -63,12 +63,12 @@ function init($container: HTMLElement | null = document.body): Array<string> {
 
   return Array.from($binders)
     .map($binder => {
-      const uploaderId = createUploader($binder)
+      const uploader = createUploader($binder)
 
-      $binder.dataset.uploaderId = uploaderId
+      $binder.dataset.uploaderId = uploader.id
       $binder.hidden = true
 
-      return uploaderId
+      return uploader
     })
     .filter(id => id !== null)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -66,13 +66,13 @@ function init($container?: HTMLElement = document.body): Array<BoundUploader> {
       const uploader = createUploader($binder)
 
       if (uploader === null) {
-        return
+        return uploaders
       }
 
       $binder.dataset.uploaderId = uploader.id
       $binder.hidden = true
 
-      uploaders.push(uploader)
+      return [...uploaders, uploader]
     }, [])
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,48 +2,55 @@
 /* @jsx h */
 
 import {h, app} from 'hyperapp'
-import './index.css'
-import {Input} from './components/Input/Input'
-import {build as buildSettings} from './modules/settings'
-import {LocalizedDemo} from './components/LocalizedDemo/LocalizedDemo'
-import {i18n, withLocales} from './i18n'
-import {ru} from './i18n/locales'
+import nanoid from 'nanoid'
 
-i18n.addLocale(ru)
+const DEFAULT_BINDERS_SELECTOR = '.uploadcare-uploader'
 
 const state = {}
 const actions = {}
 
-const view = () => (
+const Uploader = () => (
   <div>
-    Uploadcare Widget will be here.
-    <Input type='search' />
-    <LocalizedDemo />
+    Uploader will be here
   </div>
 )
 
-const init = (targetElement: HTMLElement | null = document.body) => {
-  if (!targetElement) {
+const createUploader = ($binder) => {
+  const {parentNode} = $binder
+
+  if (!parentNode) {
+    return null
+  }
+
+  const uploaderName = 'uploadcare--uploader'
+  const uploaderId = `${uploaderName}-${nanoid()}`
+  const $uploader = document.createElement('div')
+
+  $uploader.id = uploaderId
+  $uploader.classList.add(uploaderName)
+
+  parentNode.insertBefore($uploader, $binder)
+
+  app(state, actions, Uploader, $uploader)
+
+  return uploaderId
+}
+
+const init = ($container: HTMLElement | null = document.body) => {
+  if (!$container) {
     return
   }
 
-  const $widgetInputs = targetElement.querySelectorAll('.uploadcare-uploader')
+  const $binders = $container.querySelectorAll(DEFAULT_BINDERS_SELECTOR)
 
-  Array.from($widgetInputs).forEach($widgetInput => {
-    const $wrapper = document.createElement('div')
-    const parentNode = $widgetInput.parentNode
-
-    if (!parentNode) {
+  Array.from($binders).forEach($binder => {
+    if ($binder.dataset.uploaderId && document.getElementById($binder.dataset.uploaderId)) {
       return
     }
 
-    $wrapper.classList.add('uploadcare-uploader--widget')
-    parentNode.insertBefore($wrapper, $widgetInput)
-
-    const settings = buildSettings($widgetInput)
-
-    withLocales(app)(state, actions, view, $wrapper)
+    $binder.dataset.uploaderId = createUploader($binder)
+    $binder.hidden = true
   })
 }
 
-export default {uploader: {init}}
+init()


### PR DESCRIPTION
Now, we have three special words:

1. Uploader - an HTML component for uploading, can be a widget, dialog or panel
1. Binder - an HTML element that is the target to bind a new Uploader
1. Container - an HTML element in which we have to find Binders

Each Uploader has a unique id, generated by [nanoid](https://www.npmjs.com/package/nanoid). The id of Uploader saved to data attribute of Binder.

We have two functions:

* `createUploader` - creates Uploader near with Binder and returns an object with an id of Uploader, in future this object will contain all info and methods about Uploader. If Binder already has an id and a page contain Uploader with that id, returns an existing Uploader. It needs to prevent duplicates.
* `init` - creates Uploaders as many as Binders in a Container element.

Now, init starts in the module. Next, in other PR, we need to update rollup settings, export `init` as a function, and use it manually. Only in browser initialization must starts automatically.

