### PR TITLE
Fix firing onInfoReady callback

### DIFF
--- a/app/assets/javascripts/uploadcare/files/base.coffee
+++ b/app/assets/javascripts/uploadcare/files/base.coffee
@@ -99,10 +99,9 @@ namespace 'files', (ns) ->
       if @s3Bucket and @cdnUrlModifiers
         @__rejectApi('baddata')
 
-      if not @onInfoReady.fired()
+      if data.is_ready
         @onInfoReady.fire(@__fileInfo())
 
-      if data.is_ready
         @__resolveApi()
 
     #


### PR DESCRIPTION
In case when first `info` request from widget returns `is_ready: false`, then callback `onInfoReady` and validators will be fired once for non-ready info. This behaviour forces widget to accept non-image files with `images-only` enabled.

I think that `onInfoReady` supposed to be fired when info is completely ready, but for some reason it's fired even if info is not ready yet.