### PR TITLE
Run validators on each chunk of data

### DIFF
--- a/HISTORY.markdown
+++ b/HISTORY.markdown
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-* Fixed typo and improved grammar in the Dutch (`nl`) locale. See [#504][github-pr-504].
 * Fixed multipart uploading when imagesOnly flag is set.
+* Validators now run more frequently for each file than before.
+* Fixed typo and improved grammar in the Dutch (`nl`) locale. See [#504][github-pr-504].
 
 [Unreleased]: https://github.com/uploadcare/uploadcare-widget/compare/v3.6.1...HEAD
 [github-pr-504]: https://github.com/uploadcare/uploadcare-widget/pull/504


### PR DESCRIPTION
No more single `onInfoReady` event. Each chunk of data will be processed with validators (hope they are fast enough).

`wait_is_ready` flag is set depending on `isImage`: if `isImage` is not set, we don't wait for `is_ready`.