### PR TITLE
Add the default MIME type for recorded video on the camera tab

### DIFF
--- a/HISTORY.markdown
+++ b/HISTORY.markdown
@@ -12,10 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Fixed typo and improved grammar in the Dutch (`nl`) locale. See [#504][github-pr-504].
 * Fixed multipart uploading when imagesOnly flag is set.
 * Fixed the MIME type of the recorded video on the camera tab.
-  Now, the default MIME type is WebM.
+  Now, the default MIME type is WebM. See [#513][github-pr-513].
 
 [Unreleased]: https://github.com/uploadcare/uploadcare-widget/compare/v3.6.1...HEAD
 [github-pr-504]: https://github.com/uploadcare/uploadcare-widget/pull/504
+[github-pr-513]: https://github.com/uploadcare/uploadcare-widget/pull/513
 
 ## [3.6.1] - 2018-09-21
 

--- a/HISTORY.markdown
+++ b/HISTORY.markdown
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Fixed typo and improved grammar in the Dutch (`nl`) locale. See [#504][github-pr-504].
 * Fixed multipart uploading when imagesOnly flag is set.
+* Fixed the MIME type of the recorded video on the camera tab.
+  Now, the default MIME type is WebM.
 
 [Unreleased]: https://github.com/uploadcare/uploadcare-widget/compare/v3.6.1...HEAD
 [github-pr-504]: https://github.com/uploadcare/uploadcare-widget/pull/504

--- a/app/assets/javascripts/uploadcare/widget/tabs/camera-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/camera-tab.coffee
@@ -166,7 +166,9 @@ uploadcare.namespace 'widget.tabs', (ns) ->
       @__setState('recording')
 
       @__chunks = []
-      __recorderOptions = {}
+      __recorderOptions = {
+        mimeType: 'video/webm'
+      }
 
       if @settings.audioBitsPerSecond != null
         __recorderOptions.audioBitsPerSecond = @settings.audioBitsPerSecond
@@ -174,10 +176,7 @@ uploadcare.namespace 'widget.tabs', (ns) ->
       if @settings.videoBitsPerSecond != null
         __recorderOptions.videoBitsPerSecond = @settings.videoBitsPerSecond
 
-      if Object.keys(__recorderOptions).length != 0
-        @__recorder = new @MediaRecorder(@__stream, __recorderOptions)
-      else
-        @__recorder = new @MediaRecorder(@__stream)
+      @__recorder = new @MediaRecorder(@__stream, __recorderOptions)
 
       @__recorder.start()
       @__recorder.ondataavailable = (e) =>
@@ -187,12 +186,8 @@ uploadcare.namespace 'widget.tabs', (ns) ->
       @__setState('ready')
 
       @__recorder.onstop = =>
-        # I don't see any way to get correct value in Chrome.
-        # Currently Chrome and Firefox both uses webm.
-        mime = @__recorder.mimeType
-        mime = if mime then mime.split('/')[1] else 'webm'
-        blob = new Blob(@__chunks, {'type': "video/#{mime}"})
-        blob.name = "record.#{mime}"
+        blob = new Blob(@__chunks, {'type': @__recorder.mimeType})
+        blob.name = "record.webm"
         @dialogApi.addFiles('object', [[blob, {source: 'camera'}]])
         @dialogApi.switchTab('preview')
         @__chunks = []


### PR DESCRIPTION
We didn‘t set the MIME type for recording video on the camera tab, so, browsers themselves decided which MIME type to choose. Usually, it was `video/webm`. Also, we use the MIME type of the recorded video to create the extension of the recorded video. For a long time, we got a WebM video with the `record.webm` name.

But, since the Chrome 69, the MIME type has become `video/x-matroska;codecs=avc1,opus`.

I added the MIME type to options of MediaRecorder with the default value `video/webm` to get WebM videos from all cases.