### PR TITLE
Focus current menu item to return focus to content and improve accessibility

### DIFF
--- a/app/assets/javascripts/uploadcare/widget/dialog.coffee
+++ b/app/assets/javascripts/uploadcare/widget/dialog.coffee
@@ -404,13 +404,15 @@ uploadcare.namespace '', (ns) ->
             .removeClass("uploadcare--menu__item_current")
             .filter(".uploadcare--menu__item_tab_#{tab}")
             .addClass("uploadcare--menu__item_current")
-            .focus()
 
       className = "uploadcare--tab"
       @panel.find(".#{className}")
             .removeClass("#{className}_current")
             .filter(".#{className}_name_#{tab}")
             .addClass("#{className}_current")
+
+      if @tabs[tab].displayed
+        @tabs[tab].displayed()
 
       @dfd.notify(tab)
 

--- a/app/assets/javascripts/uploadcare/widget/dialog.coffee
+++ b/app/assets/javascripts/uploadcare/widget/dialog.coffee
@@ -404,6 +404,7 @@ uploadcare.namespace '', (ns) ->
             .removeClass("uploadcare--menu__item_current")
             .filter(".uploadcare--menu__item_tab_#{tab}")
             .addClass("uploadcare--menu__item_current")
+            .focus()
 
       className = "uploadcare--tab"
       @panel.find(".#{className}")

--- a/app/assets/javascripts/uploadcare/widget/tabs/camera-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/camera-tab.coffee
@@ -89,6 +89,8 @@ uploadcare.namespace 'widget.tabs', (ns) ->
           .removeClass(oldStates)
           .addClass("uploadcare--camera_status_#{newState}")
 
+      @container.find('.uploadcare--camera__button').focus()
+
     __requestCamera: =>
       @__loaded = true
       @getUserMedia.call(navigator,
@@ -228,3 +230,6 @@ uploadcare.namespace 'widget.tabs', (ns) ->
             return known_containers[container]
       # In all other cases just return the base extension for all times
       return 'avi'
+
+    displayed: =>
+      @container.find('.uploadcare--camera__button').focus()

--- a/app/assets/javascripts/uploadcare/widget/tabs/file-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/file-tab.coffee
@@ -80,3 +80,6 @@ uploadcare.namespace 'widget.tabs', (ns) ->
         .append(tabIcon)
         .on 'click', =>
           @dialogApi.switchTab(name)
+
+    displayed: =>
+      @container.find('.uploadcare--tab__action-button').focus()

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab-multiple.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab-multiple.coffee
@@ -177,3 +177,6 @@ uploadcare.namespace 'widget.tabs', (ns) ->
           @dialogApi.fileColl.remove(file)
       $(file).data('dpm-el', fileEl)
       fileEl
+
+    displayed: =>
+      @container.find('.uploadcare--preview__done').focus()

--- a/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/preview-tab.coffee
@@ -174,6 +174,8 @@ uploadcare.namespace 'widget.tabs', (ns) ->
       if state is 'error'
         @container.addClass('uploadcare--preview_status_error-' + data.error)
 
+      @container.find('.uploadcare--preview__done').focus()
+
     initImage: (imgSize, cdnModifiers) =>
       img = @container.find('.uploadcare--preview__image')
       done = @container.find('.uploadcare--preview__done')
@@ -258,3 +260,6 @@ uploadcare.namespace 'widget.tabs', (ns) ->
 
       template.remove()
       control.find('>*').eq(0).addClass(currentClass)
+
+    displayed: =>
+      @container.find('.uploadcare--preview__done').focus()

--- a/app/assets/javascripts/uploadcare/widget/tabs/remote-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/remote-tab.coffee
@@ -13,6 +13,7 @@ uploadcare.namespace 'widget.tabs', (ns) ->
       @dialogApi.progress (name) =>
         if name == @name
           @__createIframe()
+          @container.find('.uploadcare--tab__iframe').focus()
         @__sendMessage
           type: 'visibility-changed'
           visible: name == @name

--- a/app/assets/javascripts/uploadcare/widget/tabs/url-tab.coffee
+++ b/app/assets/javascripts/uploadcare/widget/tabs/url-tab.coffee
@@ -34,3 +34,6 @@ uploadcare.namespace 'widget.tabs', (ns) ->
           input.val('').trigger('change')
 
         false
+
+    displayed: =>
+      @container.find('.uploadcare--input').focus()


### PR DESCRIPTION
After choosing any file, focus is moved to file choosing dialog and doesn't return back since `<input type="hidden">` element we are using for dialog triggering is hidden.

I didn't find any way to return focus just to the webpage, no matter which element is under the focus. So this patch just focuses an item of tabs menu.

This could be temporary solution, depends on other accessibility requirements.