### PR TITLE
Event order fix

### DIFF
--- a/src/widget/base-widget.js
+++ b/src/widget/base-widget.js
@@ -21,7 +21,7 @@ uploadcare.namespace('widget', function (ns) {
       this.__onUploadComplete = $.Callbacks()
       this.__onChange = $.Callbacks().add((object) => {
         return object != null ? object.promise().done((info) => {
-          return this.__onUploadComplete.fire(info)
+          return setTimeout(() => this.__onUploadComplete.fire(info), 0)
         }) : undefined
       })
       this.__setupWidget()


### PR DESCRIPTION
This PR fixes the order of the events. 
The `onUploadComplete` event appears prior to `onChange` in case of enabling a Crop or other effects.

How to reproduce:
1. Set up the widget with crop
2. Subscribe to events
3. Upload file and apply the crop
4. Event `onUploadComplete` will be called first. The `onChange` will be after.

