### PR TITLE
Added aria-label attributes to the Open Menu and Close buttons of the…

### DIFF
--- a/src/templates/dialog.jst.ejs
+++ b/src/templates/dialog.jst.ejs
@@ -1,6 +1,6 @@
 <div class="uploadcare--dialog">
   <div class="uploadcare--dialog__container">
-    <button type="button" title="<%- ext.t('dialog.close') %>"
+    <button type="button" title="<%- ext.t('dialog.close') %>" aria-label="<%- ext.t('dialog.close') %>"
             class="uploadcare--button uploadcare--button_icon uploadcare--button_muted uploadcare--dialog__close">
       <svg role="presentation" width="32" height="32" class="uploadcare--icon">
         <use xlink:href="#uploadcare--icon-close"></use>

--- a/src/templates/dialog__panel.jst.ejs
+++ b/src/templates/dialog__panel.jst.ejs
@@ -1,6 +1,6 @@
 <div class="uploadcare--panel">
   <div class="uploadcare--menu uploadcare--panel__menu">
-    <button type="button" title="<%- ext.t('dialog.openMenu') %>"
+    <button type="button" title="<%- ext.t('dialog.openMenu') %>" aria-label="<%- ext.t('dialog.openMenu') %>"
             class="uploadcare--button uploadcare--button_icon uploadcare--button_muted uploadcare--menu__toggle">
       <svg role="presentation" width="32" height="32"
            class="uploadcare--icon uploadcare--menu__toggle-icon uploadcare--menu__toggle-icon_menu">


### PR DESCRIPTION
… dialog as the title attribute is not sufficient for accessibility.

Here is an article detailing how the title attribute is not helpful for accessibility: https://developer.paciellogroup.com/blog/2012/01/html5-accessibility-chops-title-attribute-use-and-abuse/.  I left the title attributes on the buttons because it is probably still desired that these values show as tooltips when hovered over with a mouse.