### PR TITLE
Screen Reader upload progress improvements

### DIFF
--- a/src/templates/widget.js
+++ b/src/templates/widget.js
@@ -2,12 +2,12 @@ import { html } from '../utils/html'
 import locale from '../locale'
 
 const widget = () => html`
-  <div class="uploadcare--widget">
+  <div class="uploadcare--widget" aria-describedby="uploadcare--widget__text uploadcare--widget__progress">
     <div class="uploadcare--widget__dragndrop-area">
       ${locale.t('draghere')}
     </div>
-    <div class="uploadcare--widget__progress"></div>
-    <div class="uploadcare--widget__text"></div>
+    <div id="uploadcare--widget__progress" class="uploadcare--widget__progress" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+    <div id="uploadcare--widget__text" class="uploadcare--widget__text" aria-live="polite"></div>
   </div>
 `
 

--- a/src/ui/progress.js
+++ b/src/ui/progress.js
@@ -150,6 +150,7 @@ class CanvasRenderer extends BaseRenderer {
 
   __setValue(val) {
     this.val = val
+    this.element.attr('aria-valuenow', (val * 100).toFixed(0))
     return this.update()
   }
 

--- a/src/widget/dialog.js
+++ b/src/widget/dialog.js
@@ -122,6 +122,9 @@ const openDialog = function(files, tab, settings) {
     currentDialogPr = null
     dialog.remove()
     cancelLock()
+    if (settings.multiple) {
+      return $('.uploadcare--widget').attr('tabindex', 0).focus()
+    }
     return originalFocusedElement.focus()
   })
 
@@ -481,7 +484,7 @@ class Panel {
       .insertBefore(this.footer)
     if (name === 'preview') {
       tabIcon = $(
-        '<div class="uploadcare--menu__icon uploadcare--panel__icon">'
+        '<div class="uploadcare--menu__icon uploadcare--panel__icon" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">'
       )
     } else {
       tabIcon = $(

--- a/src/widget/template.js
+++ b/src/widget/template.js
@@ -41,6 +41,7 @@ class Template {
   reset() {
     this.circle.reset()
     this.setStatus('ready')
+    this.content.attr('aria-busy', false)
     this.__file = undefined
 
     return this.__file
@@ -48,6 +49,7 @@ class Template {
 
   loaded() {
     this.setStatus('loaded')
+    this.content.attr('aria-busy', false)
     return this.circle.reset(true)
   }
 
@@ -56,6 +58,7 @@ class Template {
 
     this.circle.listen(file, 'uploadProgress')
     this.setStatus('started')
+    this.content.attr('aria-busy', true)
 
     return file.progress(info => {
       if (file === this.__file) {
@@ -71,6 +74,7 @@ class Template {
 
   error(type) {
     this.statusText.text(locale.t(`errors.${type || 'default'}`))
+    this.content.attr('aria-busy', false)
     return this.setStatus('error')
   }
 


### PR DESCRIPTION
This includes the following improvements to help those using screen readers follow the progress of the upload:

1. added a `role="progressbar"` and associated aria attributes to the progress circle
2. added a `role="status"` and `aria-live="polite"` to the `widget__text`
3. added the updating of various attributes based on the upload progress
4. added the setting of the focus back to the widget after a dialog with multiple of true is closed. Previously is was focussing on the `originalFocusedElement` which is the open button and is hidden and therefore causes the focus to go to the body instead.