### PR TITLE
Preview accessibility improvements

### DIFF
--- a/src/templates/tab-preview-multiple.js
+++ b/src/templates/tab-preview-multiple.js
@@ -4,7 +4,9 @@ import locale from '../locale'
 const tabPreviewMultiple = () => html`
   <div class="uploadcare--tab__header">
     <div
+      id="preview__title" 
       class="uploadcare--text uploadcare--text_size_large uploadcare--tab__title uploadcare--preview__title"
+      role="status" aria-live="assertive"
     ></div>
   </div>
 
@@ -27,6 +29,7 @@ const tabPreviewMultiple = () => html`
     <button
       type="button"
       class="uploadcare--button uploadcare--button_primary uploadcare--footer__button uploadcare--preview__done"
+      aria-describedby="preview_title"
     >
       ${locale.t('dialog.tabs.preview.multiple.done')}
     </button>

--- a/src/templates/tab-preview-regular.js
+++ b/src/templates/tab-preview-regular.js
@@ -5,7 +5,9 @@ import locale from '../locale'
 const tabPreviewRegular = ({ file }) => html`
   <div class="uploadcare--tab__header">
     <div
+      id="tab__title"
       class="uploadcare--text uploadcare--text_size_large uploadcare--tab__title"
+      role="status" aria-live="assertive"
     >
       ${locale.t('dialog.tabs.preview.regular.title')}
     </div>
@@ -29,6 +31,7 @@ const tabPreviewRegular = ({ file }) => html`
     <button
       type="button"
       class="uploadcare--button uploadcare--button_primary uploadcare--footer__button uploadcare--preview__done"
+      aria-describedby="tab__title"
     >
       ${locale.t('dialog.tabs.preview.done')}
     </button>

--- a/src/widget/tabs/preview-tab-multiple.js
+++ b/src/widget/tabs/preview-tab-multiple.js
@@ -106,7 +106,7 @@ class PreviewTabMultiple extends BasePreviewTab {
     fileEl
       .find('.uploadcare--file__description')
       .attr(
-        'title',
+        'aria-label',
         locale
           .t('dialog.tabs.preview.multiple.file.preview')
           .replace('%file%', filename)
@@ -118,6 +118,12 @@ class PreviewTabMultiple extends BasePreviewTab {
         locale
           .t('dialog.tabs.preview.multiple.file.remove')
           .replace('%file%', filename)
+      )
+      .attr(
+          'aria-label',
+          locale
+              .t('dialog.tabs.preview.multiple.file.remove')
+              .replace('%file%', filename)
       )
     return fileEl
       .find('.uploadcare--file__size')


### PR DESCRIPTION
Added the following various accessibility improvements to the preview panel:

1. Added a `role="status"` and `aria-live="assertive"` to the tab titles so that when they are updated the user is read the change when using a screen reader
2. Added an `aria-describedby` attribute the to "Add" buttons to point to the tab titles so that when the "Add" button is focused the screen reader user is given more context as to what they are adding
3. Added `aria-label` attributes to the Description and Remove buttons on the Preview Multiple Tab instead of relying on the `title` attributes