### PR TITLE
fix: remove prototype pollution from Pusher source

### DIFF
--- a/src/vendor/pusher.js
+++ b/src/vendor/pusher.js
@@ -16,15 +16,6 @@ const { isWindowDefined } = require('../utils/is-window-defined')
   var Pusher, _require;
 
 ;(function() {
-  if (Function.prototype.scopedTo === undefined) {
-    Function.prototype.scopedTo = function(context, args) {
-      var f = this;
-      return function() {
-        return f.apply(context, Array.prototype.slice.call(args || [])
-                       .concat(Array.prototype.slice.call(arguments)));
-      };
-    };
-  }
 
   Pusher = function(app_key, options) {
     this.options = options || {};


### PR DESCRIPTION
## Description

Pusher doesn't use `scopedTo` method as I see in https://github.com/pusher/pusher-js/commit/52f6de6b496479509713d1cee05316ce3e0efe17 and in our copy, because of that I have just dropped it

## Related issues

fix #681