### PR TITLE
Fix Firefox video mimetype

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -72,6 +72,7 @@ defaults = {
   parallelDirectUploads: 10,
   passWindowOpen: false,
   // camera recording
+  preferedMimeType: null,
   audioBitsPerSecond: null,
   videoBitsPerSecond: null,
   // maintain settings

--- a/src/settings.js
+++ b/src/settings.js
@@ -72,7 +72,7 @@ defaults = {
   parallelDirectUploads: 10,
   passWindowOpen: false,
   // camera recording
-  preferedMimeType: null,
+  videoPreferredMimeTypes: null,
   audioBitsPerSecond: null,
   videoBitsPerSecond: null,
   // maintain settings
@@ -271,7 +271,7 @@ defaultPreviewUrlCallback = function(url, info) {
 
 normalize = function(settings) {
   var skydriveIndex
-  arrayOptions(settings, ['tabs', 'preferredTypes'])
+  arrayOptions(settings, ['tabs', 'preferredTypes', 'videoPreferredMimeTypes'])
   urlOptions(settings, ['cdnBase', 'socialBase', 'urlBase', 'scriptBase'])
   flagOptions(settings, [
     'doNotStore',
@@ -326,6 +326,7 @@ normalize = function(settings) {
   if (skydriveIndex !== -1) {
     settings.tabs[skydriveIndex] = 'onedrive'
   }
+
   return settings
 }
 

--- a/src/utils/find.js
+++ b/src/utils/find.js
@@ -1,0 +1,16 @@
+function find(arr, predicate) {
+  var len = arr.length
+  var k = 0
+
+  while (k < len) {
+    var kValue = arr[k]
+    if (predicate(kValue)) {
+      return kValue
+    }
+    k++
+  }
+
+  return undefined
+}
+
+export default find

--- a/src/widget/tabs/camera-tab.js
+++ b/src/widget/tabs/camera-tab.js
@@ -289,10 +289,14 @@ class CameraTab {
 
     var mimeTypes = this.settings.videoPreferredMimeTypes
     if (mimeTypes != null) {
-      __recorderOptions.mimeType = find(
+      var mimeType = find(
         $.isArray(mimeTypes) ? mimeTypes : [mimeTypes],
         mimeType => this.MediaRecorder.isTypeSupported(mimeType)
       )
+      
+      if (mimeType != null) {
+        __recorderOptions.mimeType = mimeType
+      }
     }
 
     var isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1

--- a/src/widget/tabs/camera-tab.js
+++ b/src/widget/tabs/camera-tab.js
@@ -282,10 +282,16 @@ class CameraTab {
   }
 
   __startRecording() {
-    var __recorderOptions
     this.__setState('recording')
     this.__chunks = []
-    __recorderOptions = {}
+
+    var isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+    var __recorderOptions = isFirefox && window.MediaRecorder.isTypeSupported('video/webm')
+      ? {
+          mimeType: 'video/webm'
+        }
+      : {}
+
     if (this.settings.audioBitsPerSecond !== null) {
       __recorderOptions.audioBitsPerSecond = this.settings.audioBitsPerSecond
     }
@@ -375,7 +381,8 @@ class CameraTab {
   }
 
   displayed() {
-    this.dialogApi.takeFocus() && this.container.find('.uploadcare--camera__button').focus()
+    this.dialogApi.takeFocus() &&
+      this.container.find('.uploadcare--camera__button').focus()
   }
 }
 

--- a/src/widget/tabs/camera-tab.js
+++ b/src/widget/tabs/camera-tab.js
@@ -284,20 +284,26 @@ class CameraTab {
   __startRecording() {
     this.__setState('recording')
     this.__chunks = []
+    var __recorderOptions = {}
+
+    var mimeType = this.settings.preferedMimeType
+    if (mimeType != null && this.MediaRecorder.isTypeSupported(mimeType)) {
+      __recorderOptions.mimeType = mimeType
+    }
 
     var isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-    var __recorderOptions = isFirefox && window.MediaRecorder.isTypeSupported('video/webm')
-      ? {
-          mimeType: 'video/webm'
-        }
-      : {}
+    if ( __recorderOptions.mimeType == null && isFirefox && this.MediaRecorder.isTypeSupported('video/webm')) {
+      __recorderOptions.mimeType = 'video/webm'
+    }
 
     if (this.settings.audioBitsPerSecond !== null) {
       __recorderOptions.audioBitsPerSecond = this.settings.audioBitsPerSecond
     }
+    
     if (this.settings.videoBitsPerSecond !== null) {
       __recorderOptions.videoBitsPerSecond = this.settings.videoBitsPerSecond
     }
+    
     if (Object.keys(__recorderOptions).length !== 0) {
       this.__recorder = new this.MediaRecorder(this.__stream, __recorderOptions)
     } else {

--- a/src/widget/tabs/camera-tab.js
+++ b/src/widget/tabs/camera-tab.js
@@ -2,6 +2,7 @@ import $ from 'jquery'
 import { warn } from '../../utils/warnings'
 import { fileSelectDialog, canvasToBlob } from '../../utils'
 import { tpl } from '../../templates'
+import find from '../../utils/find'
 import { isWindowDefined } from '../../utils/is-window-defined'
 
 var isSecure = isWindowDefined() && document.location.protocol === 'https:'
@@ -286,24 +287,31 @@ class CameraTab {
     this.__chunks = []
     var __recorderOptions = {}
 
-    var mimeType = this.settings.preferedMimeType
-    if (mimeType != null && this.MediaRecorder.isTypeSupported(mimeType)) {
-      __recorderOptions.mimeType = mimeType
+    var mimeTypes = this.settings.videoPreferredMimeTypes
+    if (mimeTypes != null) {
+      __recorderOptions.mimeType = find(
+        $.isArray(mimeTypes) ? mimeTypes : [mimeTypes],
+        mimeType => this.MediaRecorder.isTypeSupported(mimeType)
+      )
     }
 
-    var isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-    if ( __recorderOptions.mimeType == null && isFirefox && this.MediaRecorder.isTypeSupported('video/webm')) {
+    var isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1
+    if (
+      __recorderOptions.mimeType == null &&
+      isFirefox &&
+      this.MediaRecorder.isTypeSupported('video/webm')
+    ) {
       __recorderOptions.mimeType = 'video/webm'
     }
 
     if (this.settings.audioBitsPerSecond !== null) {
       __recorderOptions.audioBitsPerSecond = this.settings.audioBitsPerSecond
     }
-    
+
     if (this.settings.videoBitsPerSecond !== null) {
       __recorderOptions.videoBitsPerSecond = this.settings.videoBitsPerSecond
     }
-    
+
     if (Object.keys(__recorderOptions).length !== 0) {
       this.__recorder = new this.MediaRecorder(this.__stream, __recorderOptions)
     } else {


### PR DESCRIPTION
## Description

add hardcoded `mimeType` (`video/webm`) for Firefox
add `preferedMimeType` setting for camera tab

fix #542

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
