### PR TITLE
fix: upload only one dropped file when widget in single mode

### DIFF
--- a/src/widget/tabs/file-tab.js
+++ b/src/widget/tabs/file-tab.js
@@ -24,7 +24,12 @@ class FileTab {
     dropArea = this.container.find('.uploadcare--draganddrop')
     if (fileDragAndDrop) {
       receiveDrop(dropArea, (type, files) => {
-        this.dialogApi.addFiles(type, files)
+        if (this.settings.multiple) {
+          this.dialogApi.addFiles(type, files)
+        } else {
+          this.dialogApi.addFiles(type, files[0])
+        }
+
         return this.dialogApi.switchTab('preview')
       })
       return dropArea.addClass('uploadcare--draganddrop_supported')


### PR DESCRIPTION
## Description

Upload only one dropped file in widget's file tab when widget in single mode

connected with https://github.com/uploadcare/uploadcare-widget/issues/739

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
