### PR TITLE
Added support to enable only camera photos.

### DIFF
--- a/dummy/index.html
+++ b/dummy/index.html
@@ -5,6 +5,7 @@
   <li><a href="/simple.html">default</a></li>
   <li><a href="/shrink.html">shrink</a></li>
   <li><a href="/dialog.html">dialog</a></li>
+  <li><a href="/tabs.html">tabs</a></li>
   <li><a href="/effects.html">effects tab</a></li>
   <li><a href="/effects-old.html">effects tab old</a></li>
   <li><a href="/locale.html">locale</a></li>

--- a/dummy/tabs.html
+++ b/dummy/tabs.html
@@ -1,0 +1,28 @@
+<meta charset="UTF-8" />
+<meta content="width=device-width,initial-scale=1" name="viewport"/>
+<script>
+    UPLOADCARE_PUBLIC_KEY = 'demopublickey'
+    UPLOADCARE_TABS = 'default huddle'
+    UPLOADCARE_DEBUG_UPLOADS = true
+</script>
+<script src="./uploadcare.full.js"></script>
+
+<p>
+    Camera with audio and video:
+    <input
+            type="hidden"
+            role="uploadcare-uploader"
+            data-tabs="camera"
+    />
+</p>
+
+<p>
+    Camera with photo only:
+    <input
+            type="hidden"
+            role="uploadcare-uploader"
+            data-tabs="camera"
+            data-enable-audio-recording="false"
+            data-enable-video-recording="false"
+    />
+</p>

--- a/src/settings.js
+++ b/src/settings.js
@@ -75,6 +75,8 @@ defaults = {
   // camera
   cameraMirrorDefault: true,
   // camera recording
+  enableAudioRecording: true,
+  enableVideoRecording: true,
   videoPreferredMimeTypes: null,
   audioBitsPerSecond: null,
   videoBitsPerSecond: null,

--- a/src/widget/tabs/camera-tab.js
+++ b/src/widget/tabs/camera-tab.js
@@ -91,7 +91,7 @@ class CameraTab {
     this.container
       .find('.uploadcare--camera__button_type_retry')
       .on('click', this.__requestCamera)
-    if (!this.MediaRecorder || this.settings.imagesOnly) {
+    if (!this.MediaRecorder || this.settings.imagesOnly || !this.settings.enableVideoRecording) {
       startRecord.hide()
     }
     this.video = this.container.find('.uploadcare--camera__video')
@@ -173,7 +173,7 @@ class CameraTab {
     return this.getUserMedia.call(
       navigator,
       {
-        audio: true,
+        audio: this.settings.enableAudioRecording,
         video: {
           width: {
             ideal: 1920


### PR DESCRIPTION
## Description

When enabled, this removes the video recording option and prevents the browser from requesting microphone permissions.

Demo available in dummy/tabs.html