### PR TITLE
add support for removing styles and stylesheet urls to CssCollector

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -186,9 +186,8 @@ intOptions = function (settings, keys) {
 }
 
 integrationToUserAgent = function (settings) {
-  settings._userAgent = `UploadcareWidget/${version}/${
-    settings.publicKey
-  } (JavaScript${settings.integration ? `; ${settings.integration}` : ''})`
+  settings._userAgent = `UploadcareWidget/${version}/${settings.publicKey
+    } (JavaScript${settings.integration ? `; ${settings.integration}` : ''})`
   return settings
 }
 
@@ -208,7 +207,7 @@ transformOptions = function (settings, transforms) {
 constrainOptions = function (settings, constraints) {
   var key, max, min
   for (key in constraints) {
-    ;({ min, max } = constraints[key])
+    ; ({ min, max } = constraints[key])
     if (settings[key] != null) {
       settings[key] = Math.min(Math.max(settings[key], min), max)
     }
@@ -241,8 +240,8 @@ parseShrink = function (val) {
       `Shrinked size can not be larger than ${Math.floor(
         maxSize / 1000 / 1000
       )}MP. ` +
-        `You have set ${shrink[1]}x${shrink[2]} (` +
-        `${Math.ceil(size / 1000 / 100) / 10}MP).`
+      `You have set ${shrink[1]}x${shrink[2]} (` +
+      `${Math.ceil(size / 1000 / 100) / 10}MP).`
     )
 
     return false
@@ -380,12 +379,18 @@ const CssCollector = class CssCollector {
   }
 
   addUrl(url) {
-    if (!/^https?:\/\//i.test(url)) throw new Error('Embedded urls should be absolute. ' + url)
-    if (!(this.urls.includes(url))) return this.urls.push(url)
+    if (!/^https?:\/\//i.test(url)) {
+      throw new Error('Embedded urls should be absolute. ' + url)
+    }
+    if (!(this.urls.includes(url))) {
+      return this.urls.push(url)
+    }
   }
 
   addStyle(style) {
-    if (!(this.styles.includes(style))) return this.styles.push(style)
+    if (!(this.styles.includes(style))) {
+      return this.styles.push(style)
+    }
   }
 
   removeUrl(url) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -186,8 +186,9 @@ intOptions = function (settings, keys) {
 }
 
 integrationToUserAgent = function (settings) {
-  settings._userAgent = `UploadcareWidget/${version}/${settings.publicKey
-    } (JavaScript${settings.integration ? `; ${settings.integration}` : ''})`
+  settings._userAgent = `UploadcareWidget/${version}/${
+    settings.publicKey
+  } (JavaScript${settings.integration ? `; ${settings.integration}` : ''})`
   return settings
 }
 
@@ -207,7 +208,7 @@ transformOptions = function (settings, transforms) {
 constrainOptions = function (settings, constraints) {
   var key, max, min
   for (key in constraints) {
-    ; ({ min, max } = constraints[key])
+    ;({ min, max } = constraints[key])
     if (settings[key] != null) {
       settings[key] = Math.min(Math.max(settings[key], min), max)
     }
@@ -240,8 +241,8 @@ parseShrink = function (val) {
       `Shrinked size can not be larger than ${Math.floor(
         maxSize / 1000 / 1000
       )}MP. ` +
-      `You have set ${shrink[1]}x${shrink[2]} (` +
-      `${Math.ceil(size / 1000 / 100) / 10}MP).`
+        `You have set ${shrink[1]}x${shrink[2]} (` +
+        `${Math.ceil(size / 1000 / 100) / 10}MP).`
     )
 
     return false

--- a/src/settings.js
+++ b/src/settings.js
@@ -380,16 +380,20 @@ const CssCollector = class CssCollector {
   }
 
   addUrl(url) {
-    if (!/^https?:\/\//i.test(url)) {
-      throw new Error('Embedded urls should be absolute. ' + url)
-    }
-    if (!(indexOf.call(this.urls, url) >= 0)) {
-      return this.urls.push(url)
-    }
+    if (!/^https?:\/\//i.test(url)) throw new Error('Embedded urls should be absolute. ' + url)
+    if (!(this.urls.includes(url))) return this.urls.push(url)
   }
 
   addStyle(style) {
-    return this.styles.push(style)
+    if (!(this.styles.includes(style))) return this.styles.push(style)
+  }
+
+  removeUrl(url) {
+    this.urls = this.urls.filter(item => item !== url)
+  }
+
+  removeStyle(style) {
+    this.urls = this.urls.filter(item => item !== style)
   }
 }
 


### PR DESCRIPTION
## Description
Styling with `uploadcare.tabsCss.addUrl()` and `uploadcare.tabsCss.addStyle()` would benefit from the ability to also have methods for `removeUrl()` and `removeStyle()`. This pr adds those capabilities.
The issue I came across without remove methods may never be seen in a production release, but when testing how custom iframe styling looks with a light theme and dark theme, I realized that stylesheet urls can't be toggled, so it gets stuck. 
Also, there is nothing keeping the same style tag added to the iframe repeatedly, so in testing I am seeing a new style added every time I toggle the theme. Again, probably only something that would be noticed in production, but easy enough to fix.

<!-- Link to the related issue -->
n/a
<!-- Write a brief description of the changes introduced by this PR -->

- add `removeStyle()` and `removeUrl()` methods to CssCollector. (using `array.filter()`)
- utilize `array.includes()` instead of `array.indexOf()` for checking membership
  - `array.includes` is supported in all modern environments and is more descriptive of what is actually being checked for
  - I realize that `array.indexOf(item) >= 0` is used in many other places, but that's not why I'm making this PR. I just figured I would include this small update to this action only.
- add `array.indexOf()` check to `addStyle()` to prevent the same style tag from being duplicated 

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->


## Checklist

- [x] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
