### PR TITLE
fix: remove jquery usage at the module root scope

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -96,7 +96,7 @@ defaults = {
   debugUploads: false,
   integration: ''
 }
-initialSettings = $.extend({}, defaults)
+initialSettings = { ...defaults }
 transforms = {
   multipleMax: {
     from: 0,


### PR DESCRIPTION
This caused an error `TypeError: $__default.default.extend is not a function` in some environments.