### PR TITLE
fix: do not override `isImage` flag when s3 bucket is enabled

### DIFF
--- a/src/files/base.js
+++ b/src/files/base.js
@@ -164,7 +164,7 @@ class BaseFile {
       name: this.fileName,
       size: this.fileSize,
       isStored: this.isStored,
-      isImage: !this.s3Bucket && this.isImage,
+      isImage: this.isImage,
       originalImageInfo: this.imageInfo,
       originalVideoInfo: this.videoInfo,
       originalContentInfo: this.contentInfo,


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
