### PR TITLE
feat: add dropboxchooser tab and map locale key to dropbox

### DIFF
--- a/src/widget/dialog.js
+++ b/src/widget/dialog.js
@@ -17,6 +17,12 @@ import { FileGroup } from '../files/group-creator'
 import { isFileGroup } from '../utils/groups'
 import { isWindowDefined } from '../utils/is-window-defined'
 
+const TAB_LOCALE_NAME_MAP = {
+  dropboxchooser: 'dropbox'
+}
+
+const tabLocaleName = (name) => TAB_LOCALE_NAME_MAP[name] || name
+
 const lockDialogFocus = function (e) {
   if (!e.shiftKey && focusableElements.last().is(e.target)) {
     e.preventDefault()
@@ -205,6 +211,7 @@ registerTab('url', UrlTab)
 registerTab('camera', CameraTab)
 registerTab('facebook', RemoteTab)
 registerTab('dropbox', RemoteTab)
+registerTab('dropboxchooser', RemoteTab)
 registerTab('gdrive', RemoteTab)
 registerTab('gphotos', RemoteTab)
 registerTab('instagram', RemoteTab)
@@ -502,7 +509,7 @@ class Panel {
     })
       .addClass('uploadcare--menu__item')
       .addClass(`uploadcare--menu__item_tab_${name}`)
-      .attr('title', locale.t(`dialog.tabs.names.${name}`))
+      .attr('title', locale.t(`dialog.tabs.names.${tabLocaleName(name)}`))
       .append(tabIcon)
       .appendTo(this.panel.find('.uploadcare--menu__items'))
       .on('click', () => {
@@ -614,7 +621,7 @@ class Panel {
       .addClass('uploadcare--menu__item')
       .addClass(`uploadcare--menu__item_tab_${name}`)
       .attr('aria-disabled', true)
-      .attr('title', locale.t(`dialog.tabs.names.${name}`))
+      .attr('title', locale.t(`dialog.tabs.names.${tabLocaleName(name)}`))
       .append(tabIcon)
       .appendTo(this.panel.find('.uploadcare--menu__items'))
   }

--- a/src/widget/dialog.js
+++ b/src/widget/dialog.js
@@ -498,7 +498,9 @@ class Panel {
       )
     } else {
       tabIcon = $(
-        `<svg width='32' height='32'><use xlink:href='#uploadcare--icon-${tabLocaleName(name)}'/></svg>`
+        `<svg width='32' height='32'><use xlink:href='#uploadcare--icon-${tabLocaleName(
+          name
+        )}'/></svg>`
       )
         .attr('role', 'presentation')
         .attr('class', 'uploadcare--icon uploadcare--menu__icon')
@@ -610,7 +612,9 @@ class Panel {
   __addFakeTab(name) {
     var tabIcon
     tabIcon = $(
-      `<svg width='32' height='32'><use xlink:href='#uploadcare--icon-${tabLocaleName(name)}'/></svg>`
+      `<svg width='32' height='32'><use xlink:href='#uploadcare--icon-${tabLocaleName(
+        name
+      )}'/></svg>`
     )
       .attr('role', 'presentation')
       .attr('class', 'uploadcare--icon uploadcare--menu__icon')

--- a/src/widget/dialog.js
+++ b/src/widget/dialog.js
@@ -498,7 +498,7 @@ class Panel {
       )
     } else {
       tabIcon = $(
-        `<svg width='32' height='32'><use xlink:href='#uploadcare--icon-${name}'/></svg>`
+        `<svg width='32' height='32'><use xlink:href='#uploadcare--icon-${tabLocaleName(name)}'/></svg>`
       )
         .attr('role', 'presentation')
         .attr('class', 'uploadcare--icon uploadcare--menu__icon')
@@ -610,7 +610,7 @@ class Panel {
   __addFakeTab(name) {
     var tabIcon
     tabIcon = $(
-      `<svg width='32' height='32'><use xlink:href='#uploadcare--icon-${name}'/></svg>`
+      `<svg width='32' height='32'><use xlink:href='#uploadcare--icon-${tabLocaleName(name)}'/></svg>`
     )
       .attr('role', 'presentation')
       .attr('class', 'uploadcare--icon uploadcare--menu__icon')


### PR DESCRIPTION
## Summary

- Register `dropboxchooser` as a `RemoteTab` in `dialog.js`
- Add `TAB_LOCALE_NAME_MAP` with `dropboxchooser → dropbox` so tab titles resolve to the existing Dropbox translation without adding new locale keys

## Test plan

- [ ] Verify `dropboxchooser` appears as a tab when included in `tabs` config
- [ ] Verify the tab title shows "Dropbox" (from existing locale key)
- [ ] Verify clicking opens the social source iframe with `dropboxchooser` source type

🤖 Generated with [Claude Code](https://claude.com/claude-code)